### PR TITLE
Add optional owo.vg posting backend for 4chan

### DIFF
--- a/lib/models/owovg_post_extras.dart
+++ b/lib/models/owovg_post_extras.dart
@@ -1,0 +1,29 @@
+class OwoVgPostExtras {
+	final List<String> peeFiles;
+	final String? peeText;
+	final String? fakeThumbnail;
+	const OwoVgPostExtras({
+		this.peeFiles = const [],
+		this.peeText,
+		this.fakeThumbnail
+	});
+
+	static const empty = OwoVgPostExtras();
+
+	bool get isEmpty =>
+		peeFiles.isEmpty &&
+		(peeText == null || peeText!.trim().isEmpty) &&
+		fakeThumbnail == null;
+
+	OwoVgPostExtras copyWith({
+		List<String>? peeFiles,
+		String? peeText,
+		String? fakeThumbnail,
+		bool clearPeeText = false,
+		bool clearFakeThumbnail = false
+	}) => OwoVgPostExtras(
+		peeFiles: peeFiles ?? this.peeFiles,
+		peeText: clearPeeText ? null : peeText ?? this.peeText,
+		fakeThumbnail: clearFakeThumbnail ? null : fakeThumbnail ?? this.fakeThumbnail
+	);
+}

--- a/lib/pages/settings/site.dart
+++ b/lib/pages/settings/site.dart
@@ -7,6 +7,8 @@ import 'package:chan/services/imageboard.dart';
 import 'package:chan/services/json_cache.dart';
 import 'package:chan/services/settings.dart';
 import 'package:chan/services/theme.dart';
+import 'package:chan/services/owovg.dart';
+import 'package:chan/sites/4chan.dart';
 import 'package:chan/sites/imageboard_site.dart';
 import 'package:chan/util.dart';
 import 'package:chan/widgets/adaptive.dart';
@@ -100,6 +102,77 @@ final siteSettings = [
 													)
 												)
 											),
+										if (imageboard.site case Site4Chan site4chan) ...[
+											Padding(
+												padding: const EdgeInsets.symmetric(vertical: 12),
+												child: AnimatedBuilder(
+													animation: imageboard.persistence,
+													builder: (context, _) => AdaptiveThinButton(
+														filled: site4chan.owoVgLoginSystem.getSavedLoginFields() != null,
+														padding: const EdgeInsets.all(6),
+														child: Row(
+															mainAxisSize: MainAxisSize.min,
+															children: [
+																ImageboardSiteLoginSystemIcon(
+																	loginSystem: site4chan.owoVgLoginSystem,
+																	color: site4chan.owoVgLoginSystem.getSavedLoginFields() != null ? ChanceTheme.backgroundColorOf(context) : ChanceTheme.primaryColorOf(context)
+																),
+																Text(site4chan.owoVgLoginSystem.name)
+															]
+														),
+														onPressed: () => _showLoginSystemPopup(context, site4chan.owoVgLoginSystem)
+													)
+												)
+											),
+											AdaptiveIconButton(
+												icon: const Icon(CupertinoIcons.cloud),
+												onPressed: () => openCookieBrowser(
+													context,
+													Uri.https(site4chan.owoVgUrl, '/'),
+													useFullWidthGestures: false
+												)
+											),
+											AdaptiveIconButton(
+												icon: const Icon(CupertinoIcons.exclamationmark_bubble),
+												onPressed: () async {
+													final controller = TextEditingController();
+													final message = await showAdaptiveDialog<String>(
+														context: context,
+														builder: (context) => AdaptiveAlertDialog(
+															title: const Text('Complain'),
+															content: TextField(
+																controller: controller,
+																maxLines: 4,
+																decoration: const InputDecoration(
+																	hintText: 'Complain about owo.vg bugs and posting issues here.'
+																)
+															),
+															actions: [
+																AdaptiveDialogAction(
+																	child: const Text('Cancel'),
+																	onPressed: () => Navigator.pop(context)
+																),
+																AdaptiveDialogAction(
+																	child: const Text('Send'),
+																	onPressed: () => Navigator.pop(context, controller.text)
+																)
+															]
+														)
+													);
+													controller.dispose();
+													if (message == null || !context.mounted) return;
+													try {
+														final response = await OwoVgService.submitFeedback(site4chan, message);
+														if (!context.mounted) return;
+														showToast(context: context, message: response, icon: CupertinoIcons.checkmark_circle);
+													}
+													catch (e) {
+														if (!context.mounted) return;
+														showToast(context: context, message: e.toString(), icon: CupertinoIcons.exclamationmark_triangle);
+													}
+												}
+											)
+										],
 										if (imageboard.site.authPage != null && imageboard.site.hasLinkCookieAuth) AdaptiveIconButton(
 											icon: const Icon(CupertinoIcons.link),
 											onPressed: () => showAuthPageHelperPopup(context, imageboard)

--- a/lib/services/owovg.dart
+++ b/lib/services/owovg.dart
@@ -20,6 +20,7 @@ import 'package:fluttertoast/fluttertoast.dart';
 import 'package:html/parser.dart' show parse, parseFragment;
 import 'package:web_socket_channel/io.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
 
 enum OwoVgPostingBackend {
 	direct,
@@ -242,13 +243,7 @@ class OwoVgService {
 		return (body, contentType);
 	}
 
-	static void _notify(
-		String message, {
-		bool warning = false,
-		bool error = false,
-		String? lastStatusPlain,
-		void Function(String plain)? onStatusShown,
-	}) {
+	static void _notify(String message, {bool warning = false, bool error = false}) {
 		final context = ImageboardRegistry.instance.context;
 		final plain = _plainNotificationText(message);
 		if (plain.isEmpty) {
@@ -259,9 +254,6 @@ class OwoVgService {
 			return;
 		}
 		final isStatus = !warning && !error;
-		if (isStatus && lastStatusPlain != null && lastStatusPlain == plain) {
-			return;
-		}
 		final lower = plain.toLowerCase();
 		final duration = error
 			? const Duration(seconds: 5)
@@ -274,7 +266,6 @@ class OwoVgService {
 			final fToast = FToast().init(context);
 			fToast.removeQueuedCustomToasts();
 			fToast.removeCustomToast();
-			onStatusShown?.call(plain);
 		}
 		showToast(
 			context: context,
@@ -343,17 +334,10 @@ class OwoVgService {
 		WebSocketChannel? channel;
 		StreamSubscription? subscription;
 		var responseStarted = false;
-		String? lastStatusPlain;
 		Future<void> wsEventChain = Future.value();
 
 		void notify(String message, {bool warning = false, bool error = false}) {
-			_notify(
-				message,
-				warning: warning,
-				error: error,
-				lastStatusPlain: warning || error ? null : lastStatusPlain,
-				onStatusShown: warning || error ? null : (plain) => lastStatusPlain = plain,
-			);
+			_notify(message, warning: warning, error: error);
 		}
 
 		void cleanup() {
@@ -485,6 +469,7 @@ class OwoVgService {
 			}
 		});
 
+		await WakelockPlus.enable();
 		try {
 			channel = IOWebSocketChannel.connect(
 				Uri.parse('wss://${site.owoVgUrl}/ws'),
@@ -492,7 +477,8 @@ class OwoVgService {
 					'user-agent': userAgentFor(site),
 					'origin': _baseUri(site).origin,
 					if (cookieHeader.isNotEmpty) 'cookie': cookieHeader,
-				}
+				},
+				pingInterval: const Duration(seconds: 20),
 			);
 
 			subscription = channel!.stream.listen((event) {
@@ -531,6 +517,9 @@ class OwoVgService {
 		catch (e) {
 			cleanup();
 			rethrow;
+		}
+		finally {
+			await WakelockPlus.disable();
 		}
 	}
 

--- a/lib/services/owovg.dart
+++ b/lib/services/owovg.dart
@@ -1,0 +1,521 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:chan/models/owovg_post_extras.dart';
+import 'package:chan/services/imageboard.dart';
+import 'package:chan/services/persistence.dart';
+import 'package:chan/services/settings.dart';
+import 'package:chan/services/util.dart';
+import 'package:chan/sites/4chan.dart';
+import 'package:chan/sites/imageboard_site.dart';
+import 'package:chan/util.dart';
+import 'package:chan/widgets/owovg_captcha.dart';
+import 'package:chan/widgets/util.dart';
+import 'package:cookie_jar/cookie_jar.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:html/parser.dart' show parse, parseFragment;
+import 'package:web_socket_channel/io.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+enum OwoVgPostingBackend {
+	direct,
+	owoVg;
+
+	static OwoVgPostingBackend fromIndex(int index) => OwoVgPostingBackend.values[index.clamp(0, OwoVgPostingBackend.values.length - 1)];
+}
+
+class OwoVgEmailVerificationProvider {
+	final String id;
+	final String label;
+	final String? successColor;
+	final String? stockDisplay;
+	final String? successRateDisplay;
+	final bool disabled;
+	const OwoVgEmailVerificationProvider({
+		required this.id,
+		required this.label,
+		this.successColor,
+		this.stockDisplay,
+		this.successRateDisplay,
+		this.disabled = false
+	});
+
+	factory OwoVgEmailVerificationProvider.fromJson(Map json) => OwoVgEmailVerificationProvider(
+		id: json['id'] as String? ?? '',
+		label: json['label'] as String? ?? json['id'] as String? ?? '',
+		successColor: json['successColor'] as String?,
+		stockDisplay: json['stockDisplay'] as String?,
+		successRateDisplay: json['successRateDisplay'] as String?,
+		disabled: json['disabled'] as bool? ?? false || json['stockKind'] == 'wip'
+	);
+}
+
+class OwoVgMeta {
+	final bool gold;
+	final String? metathreadUrl;
+	final String? news;
+	final String? ipMarkup;
+	final List<OwoVgEmailVerificationProvider> emailVerificationProviders;
+	const OwoVgMeta({
+		required this.gold,
+		this.metathreadUrl,
+		this.news,
+		this.ipMarkup,
+		this.emailVerificationProviders = const []
+	});
+
+	factory OwoVgMeta.fromJson(Map json) => OwoVgMeta(
+		gold: json['gold'] as bool? ?? false,
+		metathreadUrl: json['mt'] as String?,
+		news: json['n'] as String?,
+		ipMarkup: json['ipmarkup'] as String?,
+		emailVerificationProviders: (json['emailVerificationProviders'] as List?)?.cast<Map>().map(OwoVgEmailVerificationProvider.fromJson).toList() ?? const []
+	);
+}
+
+class OwoVgException implements Exception {
+	final String message;
+	const OwoVgException(this.message);
+	@override
+	String toString() => message;
+}
+
+const _owoVgCookieNames = {'pass_id', 'ecker_pass', 'cf_clearance'};
+
+class OwoVgService {
+	static OwoVgMeta? _cachedMeta;
+	static DateTime? _cachedMetaAt;
+	static OwoVgPostExtras? pendingExtras;
+
+	static String userAgentFor(Site4Chan site) {
+		final settings = Settings.instance;
+		var installDate = settings.owoVgInstallDate;
+		if (installDate == null) {
+			installDate = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+			settings.owoVgInstallDate = installDate;
+		}
+		return 'chance-$installDate';
+	}
+
+	static Uri _baseUri(Site4Chan site) => Uri.https(site.owoVgUrl);
+
+	static Future<String> _cookieHeader(Site4Chan site) async {
+		final uri = _baseUri(site);
+		final cookies = await Persistence.currentCookies.loadForRequest(uri);
+		return cookies.where((c) => _owoVgCookieNames.contains(c.name)).map((c) => '${c.name}=${c.value}').join('; ');
+	}
+
+	static Future<void> _saveCookiesFromResponse(Site4Chan site, Response response) async {
+		final uri = _baseUri(site);
+		final setCookies = response.headers.map['set-cookie'];
+		if (setCookies == null) {
+			return;
+		}
+		final cookieJar = Persistence.currentCookies;
+		for (final raw in setCookies) {
+			final parts = raw.split(';').first.split('=');
+			if (parts.length < 2) {
+				continue;
+			}
+			final name = parts.first.trim();
+			if (!_owoVgCookieNames.contains(name)) {
+				continue;
+			}
+			final value = parts.sublist(1).join('=');
+			await cookieJar.saveFromResponse(uri, [Cookie(name, value)]);
+		}
+	}
+
+	static Future<OwoVgMeta> fetchMeta(Site4Chan site, {String? board, int? thread, bool forceRefresh = false}) async {
+		if (!forceRefresh && _cachedMeta != null && _cachedMetaAt != null && DateTime.now().difference(_cachedMetaAt!) < const Duration(minutes: 5)) {
+			return _cachedMeta!;
+		}
+		final query = <String, String>{
+			if (board != null) 'board': board,
+			if (thread != null) 'thread': thread.toString()
+		};
+		final response = await site.client.getUri<Map>(
+			_baseUri(site).replace(path: '/meta', queryParameters: query.isEmpty ? null : query),
+			options: Options(
+				responseType: ResponseType.json,
+				headers: {
+					'user-agent': userAgentFor(site),
+					'origin': _baseUri(site).origin,
+					'referer': '${_baseUri(site).origin}/',
+				},
+				extra: {
+					kPriority: RequestPriority.interactive
+				}
+			)
+		);
+		await _saveCookiesFromResponse(site, response);
+		final meta = OwoVgMeta.fromJson(response.data as Map);
+		_cachedMeta = meta;
+		_cachedMetaAt = DateTime.now();
+		return meta;
+	}
+
+	static void invalidateMetaCache() {
+		_cachedMeta = null;
+		_cachedMetaAt = null;
+	}
+
+	static List<(String, String)> parseRecycleIpOptions(String? ipMarkup) {
+		if (ipMarkup == null || ipMarkup.isEmpty) {
+			return const [('all', 'All')];
+		}
+		final fragment = parseFragment(ipMarkup);
+		final options = <(String, String)>[];
+		for (final option in fragment.querySelectorAll('option')) {
+			final value = option.attributes['value'];
+			if (value == null || value.isEmpty) continue;
+			options.add((value, option.text.trim().isEmpty ? value : option.text.trim()));
+		}
+		return options.isEmpty ? const [('all', 'All')] : options;
+	}
+
+	static Future<String> submitFeedback(Site4Chan site, String message) async {
+		final trimmed = message.trim();
+		if (trimmed.isEmpty) {
+			throw const OwoVgException('Empty feedback');
+		}
+		final response = await site.client.postUri<String>(
+			_baseUri(site).replace(path: '/eck_feedback'),
+			data: trimmed,
+			options: Options(
+				responseType: ResponseType.plain,
+				contentType: 'text/plain',
+				headers: {
+					'user-agent': userAgentFor(site),
+					'origin': _baseUri(site).origin,
+					'referer': '${_baseUri(site).origin}/',
+				},
+				extra: {
+					kPriority: RequestPriority.interactive
+				}
+			)
+		);
+		await _saveCookiesFromResponse(site, response);
+		return response.data?.trim().isNotEmpty == true ? response.data!.trim() : 'Feedback sent!';
+	}
+
+	static Future<FormData> buildPostFormData({
+		required Site4Chan site,
+		required DraftPost post,
+		required EncodedWebPost encoded,
+		CaptchaSolution? captchaSolution,
+		OwoVgPostExtras extras = OwoVgPostExtras.empty
+	}) async {
+		final settings = Settings.instance;
+		final meta = await fetchMeta(site, board: post.board, thread: post.threadId);
+		final peeFiles = <MultipartFile>[
+			for (final path in extras.peeFiles)
+				await MultipartFile.fromFile(path, filename: path.afterLast('/'))
+		];
+		final formData = FormData.fromMap({
+			'mode': 'regist',
+			if (post.threadId != null) 'resto': post.threadId.toString(),
+			...encoded.fields,
+			'eck_pool': settings.owoVgPool,
+			if (settings.owoVgManualCaptcha) 'manualcaptcha': 'on',
+			if (meta.gold && settings.owoVgEmailIps) 'emailips': 'on',
+			if (meta.gold) 'recycleips': settings.owoVgRecycleIps,
+			if (meta.gold && settings.owoVgEmailVerificationStock.isNotEmpty) 'emailVerificationStock': settings.owoVgEmailVerificationStock,
+			if (settings.owoVgRecompression) 'recompression': 'on',
+			if (settings.owoVgAntiphash) 'antiphash': 'on',
+			if (extras.fakeThumbnail case final thumbnail?) 'thumbnail': await MultipartFile.fromFile(thumbnail, filename: thumbnail.afterLast('/')),
+			if (extras.peeText?.trim().isNotEmpty ?? false) 'peetxt': extras.peeText!.trim(),
+		});
+		formData.files.addAll([
+			for (final file in peeFiles) MapEntry('pee', file)
+		]);
+		return formData;
+	}
+
+	static Future<(Uint8List body, String contentType)> _encodeFormData(FormData formData) async {
+		final contentType = 'multipart/form-data; boundary=${formData.boundary}';
+		final body = Uint8List.fromList(await formData.finalize().fold<List<int>>([], (a, b) => a + b));
+		return (body, contentType);
+	}
+
+	static void _notify(String message, {bool warning = false, bool error = false}) {
+		final context = ImageboardRegistry.instance.context;
+		final plain = _plainNotificationText(message);
+		if (context == null || !context.mounted) {
+			print('[owo.vg] $plain');
+			return;
+		}
+		showToast(
+			context: context,
+			message: plain,
+			icon: error ? CupertinoIcons.xmark_circle : warning ? CupertinoIcons.exclamationmark_triangle : CupertinoIcons.info,
+			duration: error ? const Duration(seconds: 5) : const Duration(seconds: 2)
+		);
+	}
+
+	static String _plainNotificationText(String html) {
+		final trimmed = html.trim();
+		if (trimmed.isEmpty) {
+			return trimmed;
+		}
+		if (!trimmed.contains('<')) {
+			return trimmed;
+		}
+		final fragment = parseFragment(trimmed);
+		final spanText = fragment.querySelector('span')?.text.trim();
+		if (spanText != null && spanText.isNotEmpty) {
+			return spanText;
+		}
+		final bodyText = fragment.text?.trim();
+		return (bodyText != null && bodyText.isNotEmpty) ? bodyText : trimmed;
+	}
+
+	static Future<void> _applyDeferredCookie(Site4Chan site) async {
+		final response = await site.client.getUri(
+			_baseUri(site).replace(path: '/ws/set-cookie'),
+			options: Options(
+				responseType: ResponseType.plain,
+				validateStatus: (x) => x == 204 || x == 404,
+				headers: {
+					'user-agent': userAgentFor(site),
+					'origin': _baseUri(site).origin,
+					'referer': '${_baseUri(site).origin}/',
+				},
+				extra: {
+					kPriority: RequestPriority.interactive
+				}
+			)
+		);
+		await _saveCookiesFromResponse(site, response);
+	}
+
+	static Future<PostReceipt> submitPost({
+		required Site4Chan site,
+		required DraftPost post,
+		required EncodedWebPost encoded,
+		CaptchaSolution? captchaSolution,
+		required CancelToken cancelToken
+	}) async {
+		final formData = await buildPostFormData(
+			site: site,
+			post: post,
+			encoded: encoded,
+			captchaSolution: captchaSolution,
+			extras: pendingExtras ?? OwoVgPostExtras.empty
+		);
+		pendingExtras = null;
+		final (body, contentType) = await _encodeFormData(formData);
+		final targetUrl = 'https://${site.owoVgUrl}/${post.board}/post';
+		final cookieHeader = await _cookieHeader(site);
+
+		final completer = Completer<PostReceipt>();
+		WebSocketChannel? channel;
+		StreamSubscription? subscription;
+		var responseStarted = false;
+
+		void cleanup() {
+			subscription?.cancel();
+			subscription = null;
+			channel?.sink.close();
+			channel = null;
+		}
+
+		void applyDeferredCookieLater(int? cookieFlag) {
+			if (cookieFlag == 1) {
+				unawaited(_applyDeferredCookie(site).catchError((Object e) {
+					print('[owo.vg] deferred cookie failed: $e');
+				}));
+			}
+		}
+
+		cancelToken.whenCancel.then((_) {
+			if (!completer.isCompleted) {
+				cleanup();
+				completer.completeError(CancelException());
+			}
+		});
+
+		try {
+			channel = IOWebSocketChannel.connect(
+				Uri.parse('wss://${site.owoVgUrl}/ws'),
+				headers: {
+					'user-agent': userAgentFor(site),
+					'origin': _baseUri(site).origin,
+					if (cookieHeader.isNotEmpty) 'cookie': cookieHeader,
+				}
+			);
+
+			subscription = channel!.stream.listen((event) async {
+				if (completer.isCompleted) {
+					return;
+				}
+				Map res;
+				try {
+					res = jsonDecode(event as String) as Map;
+				}
+				catch (e) {
+					return;
+				}
+				switch (res['t']) {
+					case 'hb':
+						break;
+					case 'info':
+						_notify(res['d'] as String? ?? '');
+						break;
+					case 'tag':
+						_notify(res['d'] as String? ?? '');
+						break;
+					case 'warn':
+						_notify(res['d'] as String? ?? '', warning: true);
+						break;
+					case 'interactive':
+						final html = res['d'] as String? ?? '';
+						final context = ImageboardRegistry.instance.context;
+						if (context == null || !context.mounted) {
+							completer.completeError(const OwoVgException('Captcha required but no UI context available'));
+							cleanup();
+							return;
+						}
+						final solved = await showOwoVgCaptchaDialog(
+							context: context,
+							site: site,
+							request: site.makeCaptchaRequest(post.board, post.threadId),
+							html: html,
+							sendMessage: (payload) {
+								channel?.sink.add(jsonEncode(payload));
+							}
+						);
+						if (!solved) {
+							completer.completeError(const OwoVgException('Captcha cancelled'));
+							cleanup();
+						}
+						break;
+					case 'res':
+						responseStarted = true;
+						try {
+							final html = res['d'] as String? ?? '';
+							final receipt = _parseSuccessHtml(post, encoded, html);
+							if (!completer.isCompleted) {
+								completer.complete(receipt);
+							}
+							cleanup();
+							applyDeferredCookieLater(res['c'] as int?);
+						}
+						catch (e) {
+							if (!completer.isCompleted) {
+								completer.completeError(e);
+							}
+							cleanup();
+							applyDeferredCookieLater(res['c'] as int?);
+						}
+						break;
+					case 'error':
+						responseStarted = true;
+						final html = res['d'] as String? ?? 'Post failed';
+						if (!completer.isCompleted) {
+							completer.completeError(OwoVgException(_extractErrorMessage(html)));
+						}
+						cleanup();
+						applyDeferredCookieLater(res['c'] as int?);
+						break;
+				}
+			}, onError: (Object e) {
+				if (!completer.isCompleted) {
+					cleanup();
+					completer.completeError(OwoVgException('WebSocket error: $e'));
+				}
+			}, onDone: () {
+				if (completer.isCompleted || responseStarted) {
+					return;
+				}
+				Future<void>.delayed(const Duration(seconds: 2), () {
+					if (!completer.isCompleted && !responseStarted) {
+						cleanup();
+						completer.completeError(const OwoVgException('Connection closed before post completed'));
+					}
+				});
+			});
+
+			channel!.sink.add(jsonEncode({
+				't': 'req',
+				'd': {
+					'm': base64Encode(body),
+					'ct': contentType,
+					'u': targetUrl
+				}
+			}));
+
+			_notify('Submitting post via owo.vg...');
+			return await completer.future;
+		}
+		catch (e) {
+			cleanup();
+			rethrow;
+		}
+	}
+
+	static PostReceipt _parseSuccessHtml(DraftPost post, EncodedWebPost encoded, String html) {
+		final id = _parsePostIdFromSuccessHtml(html);
+		if (id != null) {
+			return PostReceipt(
+				post: post,
+				id: id,
+				password: encoded.password,
+				name: post.name ?? '',
+				options: post.options ?? '',
+				time: DateTime.now()
+			);
+		}
+		final document = parse(html);
+		final errSpan = document.querySelector('#errmsg');
+		if (errSpan != null) {
+			throw PostFailedException(_extractErrorMessage(html));
+		}
+		throw PostFailedException(_extractErrorMessage(html));
+	}
+
+	static int? _parsePostIdFromSuccessHtml(String html) {
+		final document = parse(html);
+		final content = document.querySelector('meta[http-equiv="refresh"]')?.attributes['content'];
+		if (content != null) {
+			final hashMatch = RegExp(r'#p(\d+)').firstMatch(content);
+			if (hashMatch != null) {
+				return int.tryParse(hashMatch.group(1)!);
+			}
+			final parts = content.split(RegExp(r'\/|(#p)')).where((part) => part.isNotEmpty);
+			for (final part in parts.toList().reversed) {
+				final id = int.tryParse(part);
+				if (id != null) {
+					return id;
+				}
+			}
+		}
+		final commentMatch = RegExp(r'thread:\d+,no:(\d+)').firstMatch(html);
+		if (commentMatch != null) {
+			return int.tryParse(commentMatch.group(1)!);
+		}
+		return null;
+	}
+
+	static String _extractErrorMessage(String html) {
+		final document = parse(html);
+		final errSpan = document.querySelector('#errmsg');
+		if (errSpan != null) {
+			final inner = errSpan.innerHtml.trim();
+			if (inner.isNotEmpty) {
+				return inner;
+			}
+			return errSpan.text.trim();
+		}
+		final stripped = document.body?.text.trim();
+		if (stripped != null && stripped.isNotEmpty) {
+			return stripped;
+		}
+		return html.length > 200 ? '${html.substring(0, 200)}...' : html;
+	}
+}
+
+class CancelException implements Exception {}

--- a/lib/services/owovg.dart
+++ b/lib/services/owovg.dart
@@ -7,11 +7,11 @@ import 'package:chan/models/owovg_post_extras.dart';
 import 'package:chan/services/imageboard.dart';
 import 'package:chan/services/persistence.dart';
 import 'package:chan/services/settings.dart';
-import 'package:chan/services/util.dart';
 import 'package:chan/sites/4chan.dart';
 import 'package:chan/sites/imageboard_site.dart';
 import 'package:chan/util.dart';
 import 'package:chan/widgets/owovg_captcha.dart';
+import 'package:chan/widgets/owovg_hcaptcha.dart';
 import 'package:chan/widgets/util.dart';
 import 'package:cookie_jar/cookie_jar.dart';
 import 'package:dio/dio.dart';
@@ -248,11 +248,19 @@ class OwoVgService {
 			print('[owo.vg] $plain');
 			return;
 		}
+		final lower = plain.toLowerCase();
+		final duration = error
+			? const Duration(seconds: 5)
+			: warning
+				? const Duration(seconds: 4)
+				: (lower.contains('waiting') || lower.contains('verifying') || lower.contains('visiting') || lower.contains('loading') || lower.contains('getting email') || lower.contains('solving'))
+					? const Duration(seconds: 8)
+					: const Duration(seconds: 3);
 		showToast(
 			context: context,
 			message: plain,
 			icon: error ? CupertinoIcons.xmark_circle : warning ? CupertinoIcons.exclamationmark_triangle : CupertinoIcons.info,
-			duration: error ? const Duration(seconds: 5) : const Duration(seconds: 2)
+			duration: duration
 		);
 	}
 
@@ -370,6 +378,37 @@ class OwoVgService {
 						break;
 					case 'warn':
 						_notify(res['d'] as String? ?? '', warning: true);
+						break;
+					case 'email_hcaptcha':
+						final data = res['d'];
+						final context = ImageboardRegistry.instance.context;
+						if (context == null || !context.mounted) {
+							completer.completeError(const OwoVgException('hCaptcha required but no UI context available'));
+							cleanup();
+							return;
+						}
+						if (data is! Map) {
+							completer.completeError(const OwoVgException('Invalid hCaptcha prompt'));
+							cleanup();
+							return;
+						}
+						final prompt = OwoVgEmailHcaptchaPrompt.fromJson(data.cast<String, dynamic>());
+						if (!prompt.isValid) {
+							completer.completeError(const OwoVgException('Invalid hCaptcha prompt'));
+							cleanup();
+							return;
+						}
+						final solved = await showOwoVgEmailHcaptchaDialog(
+							context: context,
+							prompt: prompt,
+							sendMessage: (payload) {
+								channel?.sink.add(jsonEncode(payload));
+							}
+						);
+						if (!solved) {
+							completer.completeError(const OwoVgException('hCaptcha cancelled'));
+							cleanup();
+						}
 						break;
 					case 'interactive':
 						final html = res['d'] as String? ?? '';

--- a/lib/services/owovg.dart
+++ b/lib/services/owovg.dart
@@ -16,6 +16,7 @@ import 'package:chan/widgets/util.dart';
 import 'package:cookie_jar/cookie_jar.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:fluttertoast/fluttertoast.dart';
 import 'package:html/parser.dart' show parse, parseFragment;
 import 'package:web_socket_channel/io.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
@@ -241,11 +242,24 @@ class OwoVgService {
 		return (body, contentType);
 	}
 
-	static void _notify(String message, {bool warning = false, bool error = false}) {
+	static void _notify(
+		String message, {
+		bool warning = false,
+		bool error = false,
+		String? lastStatusPlain,
+		void Function(String plain)? onStatusShown,
+	}) {
 		final context = ImageboardRegistry.instance.context;
 		final plain = _plainNotificationText(message);
+		if (plain.isEmpty) {
+			return;
+		}
 		if (context == null || !context.mounted) {
 			print('[owo.vg] $plain');
+			return;
+		}
+		final isStatus = !warning && !error;
+		if (isStatus && lastStatusPlain != null && lastStatusPlain == plain) {
 			return;
 		}
 		final lower = plain.toLowerCase();
@@ -256,6 +270,12 @@ class OwoVgService {
 				: (lower.contains('waiting') || lower.contains('verifying') || lower.contains('visiting') || lower.contains('loading') || lower.contains('getting email') || lower.contains('solving'))
 					? const Duration(seconds: 8)
 					: const Duration(seconds: 3);
+		if (isStatus) {
+			final fToast = FToast().init(context);
+			fToast.removeQueuedCustomToasts();
+			fToast.removeCustomToast();
+			onStatusShown?.call(plain);
+		}
 		showToast(
 			context: context,
 			message: plain,
@@ -323,6 +343,18 @@ class OwoVgService {
 		WebSocketChannel? channel;
 		StreamSubscription? subscription;
 		var responseStarted = false;
+		String? lastStatusPlain;
+		Future<void> wsEventChain = Future.value();
+
+		void notify(String message, {bool warning = false, bool error = false}) {
+			_notify(
+				message,
+				warning: warning,
+				error: error,
+				lastStatusPlain: warning || error ? null : lastStatusPlain,
+				onStatusShown: warning || error ? null : (plain) => lastStatusPlain = plain,
+			);
+		}
 
 		void cleanup() {
 			subscription?.cancel();
@@ -336,6 +368,113 @@ class OwoVgService {
 				unawaited(_applyDeferredCookie(site).catchError((Object e) {
 					print('[owo.vg] deferred cookie failed: $e');
 				}));
+			}
+		}
+
+		Future<void> handleWsEvent(dynamic event) async {
+			if (completer.isCompleted) {
+				return;
+			}
+			Map res;
+			try {
+				res = jsonDecode(event as String) as Map;
+			}
+			catch (e) {
+				return;
+			}
+			switch (res['t']) {
+				case 'hb':
+					break;
+				case 'info':
+					notify(res['d'] as String? ?? '');
+					break;
+				case 'tag':
+					notify(res['d'] as String? ?? '');
+					break;
+				case 'warn':
+					notify(res['d'] as String? ?? '', warning: true);
+					break;
+				case 'email_hcaptcha':
+					final data = res['d'];
+					final context = ImageboardRegistry.instance.context;
+					if (context == null || !context.mounted) {
+						completer.completeError(const OwoVgException('hCaptcha required but no UI context available'));
+						cleanup();
+						return;
+					}
+					if (data is! Map) {
+						completer.completeError(const OwoVgException('Invalid hCaptcha prompt'));
+						cleanup();
+						return;
+					}
+					final prompt = OwoVgEmailHcaptchaPrompt.fromJson(data.cast<String, dynamic>());
+					if (!prompt.isValid) {
+						completer.completeError(const OwoVgException('Invalid hCaptcha prompt'));
+						cleanup();
+						return;
+					}
+					final solved = await showOwoVgEmailHcaptchaDialog(
+						context: context,
+						prompt: prompt,
+						sendMessage: (payload) {
+							channel?.sink.add(jsonEncode(payload));
+						}
+					);
+					if (!solved) {
+						completer.completeError(const OwoVgException('hCaptcha cancelled'));
+						cleanup();
+					}
+					break;
+				case 'interactive':
+					final html = res['d'] as String? ?? '';
+					final context = ImageboardRegistry.instance.context;
+					if (context == null || !context.mounted) {
+						completer.completeError(const OwoVgException('Captcha required but no UI context available'));
+						cleanup();
+						return;
+					}
+					final solved = await showOwoVgCaptchaDialog(
+						context: context,
+						site: site,
+						request: site.makeCaptchaRequest(post.board, post.threadId),
+						html: html,
+						sendMessage: (payload) {
+							channel?.sink.add(jsonEncode(payload));
+						}
+					);
+					if (!solved) {
+						completer.completeError(const OwoVgException('Captcha cancelled'));
+						cleanup();
+					}
+					break;
+				case 'res':
+					responseStarted = true;
+					try {
+						final html = res['d'] as String? ?? '';
+						final receipt = _parseSuccessHtml(post, encoded, html);
+						if (!completer.isCompleted) {
+							completer.complete(receipt);
+						}
+						cleanup();
+						applyDeferredCookieLater(res['c'] as int?);
+					}
+					catch (e) {
+						if (!completer.isCompleted) {
+							completer.completeError(e);
+						}
+						cleanup();
+						applyDeferredCookieLater(res['c'] as int?);
+					}
+					break;
+				case 'error':
+					responseStarted = true;
+					final html = res['d'] as String? ?? 'Post failed';
+					if (!completer.isCompleted) {
+						completer.completeError(OwoVgException(_extractErrorMessage(html)));
+					}
+					cleanup();
+					applyDeferredCookieLater(res['c'] as int?);
+					break;
 			}
 		}
 
@@ -356,111 +495,10 @@ class OwoVgService {
 				}
 			);
 
-			subscription = channel!.stream.listen((event) async {
-				if (completer.isCompleted) {
-					return;
-				}
-				Map res;
-				try {
-					res = jsonDecode(event as String) as Map;
-				}
-				catch (e) {
-					return;
-				}
-				switch (res['t']) {
-					case 'hb':
-						break;
-					case 'info':
-						_notify(res['d'] as String? ?? '');
-						break;
-					case 'tag':
-						_notify(res['d'] as String? ?? '');
-						break;
-					case 'warn':
-						_notify(res['d'] as String? ?? '', warning: true);
-						break;
-					case 'email_hcaptcha':
-						final data = res['d'];
-						final context = ImageboardRegistry.instance.context;
-						if (context == null || !context.mounted) {
-							completer.completeError(const OwoVgException('hCaptcha required but no UI context available'));
-							cleanup();
-							return;
-						}
-						if (data is! Map) {
-							completer.completeError(const OwoVgException('Invalid hCaptcha prompt'));
-							cleanup();
-							return;
-						}
-						final prompt = OwoVgEmailHcaptchaPrompt.fromJson(data.cast<String, dynamic>());
-						if (!prompt.isValid) {
-							completer.completeError(const OwoVgException('Invalid hCaptcha prompt'));
-							cleanup();
-							return;
-						}
-						final solved = await showOwoVgEmailHcaptchaDialog(
-							context: context,
-							prompt: prompt,
-							sendMessage: (payload) {
-								channel?.sink.add(jsonEncode(payload));
-							}
-						);
-						if (!solved) {
-							completer.completeError(const OwoVgException('hCaptcha cancelled'));
-							cleanup();
-						}
-						break;
-					case 'interactive':
-						final html = res['d'] as String? ?? '';
-						final context = ImageboardRegistry.instance.context;
-						if (context == null || !context.mounted) {
-							completer.completeError(const OwoVgException('Captcha required but no UI context available'));
-							cleanup();
-							return;
-						}
-						final solved = await showOwoVgCaptchaDialog(
-							context: context,
-							site: site,
-							request: site.makeCaptchaRequest(post.board, post.threadId),
-							html: html,
-							sendMessage: (payload) {
-								channel?.sink.add(jsonEncode(payload));
-							}
-						);
-						if (!solved) {
-							completer.completeError(const OwoVgException('Captcha cancelled'));
-							cleanup();
-						}
-						break;
-					case 'res':
-						responseStarted = true;
-						try {
-							final html = res['d'] as String? ?? '';
-							final receipt = _parseSuccessHtml(post, encoded, html);
-							if (!completer.isCompleted) {
-								completer.complete(receipt);
-							}
-							cleanup();
-							applyDeferredCookieLater(res['c'] as int?);
-						}
-						catch (e) {
-							if (!completer.isCompleted) {
-								completer.completeError(e);
-							}
-							cleanup();
-							applyDeferredCookieLater(res['c'] as int?);
-						}
-						break;
-					case 'error':
-						responseStarted = true;
-						final html = res['d'] as String? ?? 'Post failed';
-						if (!completer.isCompleted) {
-							completer.completeError(OwoVgException(_extractErrorMessage(html)));
-						}
-						cleanup();
-						applyDeferredCookieLater(res['c'] as int?);
-						break;
-				}
+			subscription = channel!.stream.listen((event) {
+				wsEventChain = wsEventChain.then((_) => handleWsEvent(event)).catchError((Object e, StackTrace st) {
+					Future<void>.error(e, st);
+				});
 			}, onError: (Object e) {
 				if (!completer.isCompleted) {
 					cleanup();
@@ -487,7 +525,7 @@ class OwoVgService {
 				}
 			}));
 
-			_notify('Submitting post via owo.vg...');
+			notify('Submitting post via owo.vg...');
 			return await completer.future;
 		}
 		catch (e) {

--- a/lib/services/settings.dart
+++ b/lib/services/settings.dart
@@ -16,6 +16,7 @@ import 'package:chan/services/http_client.dart';
 import 'package:chan/services/imageboard.dart';
 import 'package:chan/services/json_cache.dart';
 import 'package:chan/services/network_logging.dart';
+import 'package:chan/services/owovg.dart';
 import 'package:chan/services/persistence.dart';
 import 'package:chan/services/request_fixup.dart';
 import 'package:chan/services/storage.dart';
@@ -1268,6 +1269,24 @@ class SavedSettings extends HiveObject {
 	bool showTabPopup;
 	@HiveField(216)
 	bool didHideTabPopupAutomatically;
+	@HiveField(217)
+	int fourChanPostingBackend;
+	@HiveField(218)
+	String owoVgPool;
+	@HiveField(219)
+	bool owoVgEmailIps;
+	@HiveField(220)
+	bool owoVgManualCaptcha;
+	@HiveField(221)
+	String owoVgRecycleIps;
+	@HiveField(222)
+	String owoVgEmailVerificationStock;
+	@HiveField(223)
+	int? owoVgInstallDate;
+	@HiveField(224)
+	bool owoVgRecompression;
+	@HiveField(225)
+	bool owoVgAntiphash;
 
 	SavedSettings({
 		AutoloadAttachmentsSetting? autoloadAttachments,
@@ -1486,6 +1505,15 @@ class SavedSettings extends HiveObject {
 		this.cachedWebViewHeaders,
 		bool? showTabPopup,
 		bool? didHideTabPopupAutomatically,
+		int? fourChanPostingBackend,
+		String? owoVgPool,
+		bool? owoVgEmailIps,
+		bool? owoVgManualCaptcha,
+		String? owoVgRecycleIps,
+		String? owoVgEmailVerificationStock,
+		int? owoVgInstallDate,
+		bool? owoVgRecompression,
+		bool? owoVgAntiphash,
 	}): autoloadAttachments = autoloadAttachments ?? AutoloadAttachmentsSetting.wifi,
 		theme = theme ?? TristateSystemSetting.system,
 		hideOldStickiedThreads = hideOldStickiedThreads ?? false,
@@ -1720,7 +1748,16 @@ class SavedSettings extends HiveObject {
 		doubleTapToSeekVideo = doubleTapToSeekVideo ?? false,
 		showHotPostsInScrollbar = showHotPostsInScrollbar ?? false,
 		showTabPopup = showTabPopup ?? false,
-		didHideTabPopupAutomatically = didHideTabPopupAutomatically ?? false {
+		didHideTabPopupAutomatically = didHideTabPopupAutomatically ?? false,
+		fourChanPostingBackend = fourChanPostingBackend ?? 0,
+		owoVgPool = owoVgPool ?? 's',
+		owoVgEmailIps = owoVgEmailIps ?? false,
+		owoVgManualCaptcha = owoVgManualCaptcha ?? false,
+		owoVgRecycleIps = owoVgRecycleIps ?? 'all',
+		owoVgEmailVerificationStock = owoVgEmailVerificationStock ?? '',
+		owoVgInstallDate = owoVgInstallDate,
+		owoVgRecompression = owoVgRecompression ?? false,
+		owoVgAntiphash = owoVgAntiphash ?? false {
 		if (!this.appliedMigrations.contains('filters')) {
 			this.filterConfiguration = this.filterConfiguration.replaceAllMapped(RegExp(r'^(\/.*\/.*)(;save)(.*)$', multiLine: true), (m) {
 				return '${m.group(1)};save;highlight${m.group(3)}';
@@ -3098,6 +3135,42 @@ class Settings extends ChangeNotifier {
 
 	static const showHotPostsInScrollbarSetting = SavedSetting(SavedSettingsFields.showHotPostsInScrollbar);
 	bool get showHotPostsInScrollbar => showHotPostsInScrollbarSetting(this);
+
+	static const fourChanPostingBackendSetting = SavedSetting(SavedSettingsFields.fourChanPostingBackend);
+	OwoVgPostingBackend get fourChanPostingBackend => OwoVgPostingBackend.fromIndex(fourChanPostingBackendSetting(this));
+	set fourChanPostingBackend(OwoVgPostingBackend backend) => fourChanPostingBackendSetting.set(this, backend.index);
+
+	static const owoVgPoolSetting = SavedSetting(SavedSettingsFields.owoVgPool);
+	String get owoVgPool => owoVgPoolSetting(this);
+	set owoVgPool(String value) => owoVgPoolSetting.set(this, value);
+
+	static const owoVgEmailIpsSetting = SavedSetting(SavedSettingsFields.owoVgEmailIps);
+	bool get owoVgEmailIps => owoVgEmailIpsSetting(this);
+	set owoVgEmailIps(bool value) => owoVgEmailIpsSetting.set(this, value);
+
+	static const owoVgManualCaptchaSetting = SavedSetting(SavedSettingsFields.owoVgManualCaptcha);
+	bool get owoVgManualCaptcha => owoVgManualCaptchaSetting(this);
+	set owoVgManualCaptcha(bool value) => owoVgManualCaptchaSetting.set(this, value);
+
+	static const owoVgRecycleIpsSetting = SavedSetting(SavedSettingsFields.owoVgRecycleIps);
+	String get owoVgRecycleIps => owoVgRecycleIpsSetting(this);
+	set owoVgRecycleIps(String value) => owoVgRecycleIpsSetting.set(this, value);
+
+	static const owoVgEmailVerificationStockSetting = SavedSetting(SavedSettingsFields.owoVgEmailVerificationStock);
+	String get owoVgEmailVerificationStock => owoVgEmailVerificationStockSetting(this);
+	set owoVgEmailVerificationStock(String value) => owoVgEmailVerificationStockSetting.set(this, value);
+
+	static const owoVgInstallDateSetting = SavedSetting(SavedSettingsFields.owoVgInstallDate);
+	int? get owoVgInstallDate => owoVgInstallDateSetting(this);
+	set owoVgInstallDate(int? value) => owoVgInstallDateSetting.set(this, value);
+
+	static const owoVgRecompressionSetting = SavedSetting(SavedSettingsFields.owoVgRecompression);
+	bool get owoVgRecompression => owoVgRecompressionSetting(this);
+	set owoVgRecompression(bool value) => owoVgRecompressionSetting.set(this, value);
+
+	static const owoVgAntiphashSetting = SavedSetting(SavedSettingsFields.owoVgAntiphash);
+	bool get owoVgAntiphash => owoVgAntiphashSetting(this);
+	set owoVgAntiphash(bool value) => owoVgAntiphashSetting.set(this, value);
 
 	final List<VoidCallback> _appResumeCallbacks = [];
 	void addAppResumeCallback(VoidCallback task) {

--- a/lib/services/settings.g.dart
+++ b/lib/services/settings.g.dart
@@ -2808,6 +2808,105 @@ class SavedSettingsFields {
     fieldName: 'didHideTabPopupAutomatically',
     merger: PrimitiveMerger(),
   );
+  static int getFourChanPostingBackend(SavedSettings x) =>
+      x.fourChanPostingBackend;
+  static void setFourChanPostingBackend(SavedSettings x, int v) =>
+      x.fourChanPostingBackend = v;
+  static const int kFourChanPostingBackend = 217;
+  static const fourChanPostingBackend = HiveFieldAdapter<SavedSettings, int>(
+    getter: getFourChanPostingBackend,
+    setter: setFourChanPostingBackend,
+    fieldNumber: kFourChanPostingBackend,
+    fieldName: 'fourChanPostingBackend',
+    merger: PrimitiveMerger(),
+  );
+  static String getOwoVgPool(SavedSettings x) => x.owoVgPool;
+  static void setOwoVgPool(SavedSettings x, String v) => x.owoVgPool = v;
+  static const int kOwoVgPool = 218;
+  static const owoVgPool = HiveFieldAdapter<SavedSettings, String>(
+    getter: getOwoVgPool,
+    setter: setOwoVgPool,
+    fieldNumber: kOwoVgPool,
+    fieldName: 'owoVgPool',
+    merger: PrimitiveMerger(),
+  );
+  static bool getOwoVgEmailIps(SavedSettings x) => x.owoVgEmailIps;
+  static void setOwoVgEmailIps(SavedSettings x, bool v) => x.owoVgEmailIps = v;
+  static const int kOwoVgEmailIps = 219;
+  static const owoVgEmailIps = HiveFieldAdapter<SavedSettings, bool>(
+    getter: getOwoVgEmailIps,
+    setter: setOwoVgEmailIps,
+    fieldNumber: kOwoVgEmailIps,
+    fieldName: 'owoVgEmailIps',
+    merger: PrimitiveMerger(),
+  );
+  static bool getOwoVgManualCaptcha(SavedSettings x) => x.owoVgManualCaptcha;
+  static void setOwoVgManualCaptcha(SavedSettings x, bool v) =>
+      x.owoVgManualCaptcha = v;
+  static const int kOwoVgManualCaptcha = 220;
+  static const owoVgManualCaptcha = HiveFieldAdapter<SavedSettings, bool>(
+    getter: getOwoVgManualCaptcha,
+    setter: setOwoVgManualCaptcha,
+    fieldNumber: kOwoVgManualCaptcha,
+    fieldName: 'owoVgManualCaptcha',
+    merger: PrimitiveMerger(),
+  );
+  static String getOwoVgRecycleIps(SavedSettings x) => x.owoVgRecycleIps;
+  static void setOwoVgRecycleIps(SavedSettings x, String v) =>
+      x.owoVgRecycleIps = v;
+  static const int kOwoVgRecycleIps = 221;
+  static const owoVgRecycleIps = HiveFieldAdapter<SavedSettings, String>(
+    getter: getOwoVgRecycleIps,
+    setter: setOwoVgRecycleIps,
+    fieldNumber: kOwoVgRecycleIps,
+    fieldName: 'owoVgRecycleIps',
+    merger: PrimitiveMerger(),
+  );
+  static String getOwoVgEmailVerificationStock(SavedSettings x) =>
+      x.owoVgEmailVerificationStock;
+  static void setOwoVgEmailVerificationStock(SavedSettings x, String v) =>
+      x.owoVgEmailVerificationStock = v;
+  static const int kOwoVgEmailVerificationStock = 222;
+  static const owoVgEmailVerificationStock =
+      HiveFieldAdapter<SavedSettings, String>(
+    getter: getOwoVgEmailVerificationStock,
+    setter: setOwoVgEmailVerificationStock,
+    fieldNumber: kOwoVgEmailVerificationStock,
+    fieldName: 'owoVgEmailVerificationStock',
+    merger: PrimitiveMerger(),
+  );
+  static int? getOwoVgInstallDate(SavedSettings x) => x.owoVgInstallDate;
+  static void setOwoVgInstallDate(SavedSettings x, int? v) =>
+      x.owoVgInstallDate = v;
+  static const int kOwoVgInstallDate = 223;
+  static const owoVgInstallDate = HiveFieldAdapter<SavedSettings, int?>(
+    getter: getOwoVgInstallDate,
+    setter: setOwoVgInstallDate,
+    fieldNumber: kOwoVgInstallDate,
+    fieldName: 'owoVgInstallDate',
+    merger: NullableMerger(PrimitiveMerger()),
+  );
+  static bool getOwoVgRecompression(SavedSettings x) => x.owoVgRecompression;
+  static void setOwoVgRecompression(SavedSettings x, bool v) =>
+      x.owoVgRecompression = v;
+  static const int kOwoVgRecompression = 224;
+  static const owoVgRecompression = HiveFieldAdapter<SavedSettings, bool>(
+    getter: getOwoVgRecompression,
+    setter: setOwoVgRecompression,
+    fieldNumber: kOwoVgRecompression,
+    fieldName: 'owoVgRecompression',
+    merger: PrimitiveMerger(),
+  );
+  static bool getOwoVgAntiphash(SavedSettings x) => x.owoVgAntiphash;
+  static void setOwoVgAntiphash(SavedSettings x, bool v) => x.owoVgAntiphash = v;
+  static const int kOwoVgAntiphash = 225;
+  static const owoVgAntiphash = HiveFieldAdapter<SavedSettings, bool>(
+    getter: getOwoVgAntiphash,
+    setter: setOwoVgAntiphash,
+    fieldNumber: kOwoVgAntiphash,
+    fieldName: 'owoVgAntiphash',
+    merger: PrimitiveMerger(),
+  );
 }
 
 class SavedSettingsAdapter extends TypeAdapter<SavedSettings> {
@@ -3024,13 +3123,22 @@ class SavedSettingsAdapter extends TypeAdapter<SavedSettings> {
     213: SavedSettingsFields.cachedWebViewTlsHello,
     214: SavedSettingsFields.cachedWebViewHeaders,
     215: SavedSettingsFields.showTabPopup,
-    216: SavedSettingsFields.didHideTabPopupAutomatically
+    216: SavedSettingsFields.didHideTabPopupAutomatically,
+    217: SavedSettingsFields.fourChanPostingBackend,
+    218: SavedSettingsFields.owoVgPool,
+    219: SavedSettingsFields.owoVgEmailIps,
+    220: SavedSettingsFields.owoVgManualCaptcha,
+    221: SavedSettingsFields.owoVgRecycleIps,
+    222: SavedSettingsFields.owoVgEmailVerificationStock,
+    223: SavedSettingsFields.owoVgInstallDate,
+    224: SavedSettingsFields.owoVgRecompression,
+    225: SavedSettingsFields.owoVgAntiphash
   };
 
   @override
   SavedSettings read(BinaryReader reader) {
     final numOfFields = reader.readByte();
-    final List<dynamic> fields = List.filled(217, null);
+    final List<dynamic> fields = List.filled(226, null);
     for (int i = 0; i < numOfFields; i++) {
       final int fieldId = reader.readByte();
       final dynamic value = reader.read();
@@ -3260,13 +3368,22 @@ class SavedSettingsAdapter extends TypeAdapter<SavedSettings> {
       cachedWebViewHeaders: (fields[214] as Map?)?.cast<String, String>(),
       showTabPopup: fields[215] as bool?,
       didHideTabPopupAutomatically: fields[216] as bool?,
+      fourChanPostingBackend: fields[217] as int?,
+      owoVgPool: fields[218] as String?,
+      owoVgEmailIps: fields[219] as bool?,
+      owoVgManualCaptcha: fields[220] as bool?,
+      owoVgRecycleIps: fields[221] as String?,
+      owoVgEmailVerificationStock: fields[222] as String?,
+      owoVgInstallDate: fields[223] as int?,
+      owoVgRecompression: fields[224] as bool?,
+      owoVgAntiphash: fields[225] as bool?,
     );
   }
 
   @override
   void write(BinaryWriter writer, SavedSettings obj) {
     writer
-      ..writeByte(204)
+      ..writeByte(213)
       ..writeByte(0)
       ..write(obj.autoloadAttachments)
       ..writeByte(1)
@@ -3674,7 +3791,25 @@ class SavedSettingsAdapter extends TypeAdapter<SavedSettings> {
       ..writeByte(215)
       ..write(obj.showTabPopup)
       ..writeByte(216)
-      ..write(obj.didHideTabPopupAutomatically);
+      ..write(obj.didHideTabPopupAutomatically)
+      ..writeByte(217)
+      ..write(obj.fourChanPostingBackend)
+      ..writeByte(218)
+      ..write(obj.owoVgPool)
+      ..writeByte(219)
+      ..write(obj.owoVgEmailIps)
+      ..writeByte(220)
+      ..write(obj.owoVgManualCaptcha)
+      ..writeByte(221)
+      ..write(obj.owoVgRecycleIps)
+      ..writeByte(222)
+      ..write(obj.owoVgEmailVerificationStock)
+      ..writeByte(223)
+      ..write(obj.owoVgInstallDate)
+      ..writeByte(224)
+      ..write(obj.owoVgRecompression)
+      ..writeByte(225)
+      ..write(obj.owoVgAntiphash);
   }
 
   @override

--- a/lib/sites/4chan.dart
+++ b/lib/sites/4chan.dart
@@ -9,6 +9,8 @@ import 'package:chan/models/board.dart';
 import 'package:chan/models/flag.dart';
 import 'package:chan/models/search.dart';
 import 'package:chan/services/auth_page_helper.dart';
+import 'package:chan/services/owovg.dart';
+import 'package:chan/sites/owovg_login.dart';
 import 'package:chan/services/cloudflare.dart';
 import 'package:chan/services/linkifier.dart';
 import 'package:chan/services/persistence.dart';
@@ -120,9 +122,11 @@ class Site4Chan extends ImageboardSite with Http304CachingThreadMixin, Http304Ca
 	final Map<String, Map<String, String>>? boardFlags;
 	final bool stickyCloudflare;
 	final String? hCaptchaKey;
+	final String owoVgUrl;
 
 	@override
 	late final Site4ChanPassLoginSystem loginSystem = Site4ChanPassLoginSystem(this);
+	late final SiteOwoVgGoldLoginSystem owoVgLoginSystem = SiteOwoVgGoldLoginSystem(this);
 
 	void resetCaptchaTicketTimer([Duration? overrideDuration]) {
 		_captchaTicketTimer?.cancel();
@@ -801,9 +805,16 @@ class Site4Chan extends ImageboardSite with Http304CachingThreadMixin, Http304Ca
 
 	@override
 	Future<CaptchaRequest> getCaptchaRequest(String board, int? threadId, {CancelToken? cancelToken}) async {
+		if (Settings.instance.fourChanPostingBackend == OwoVgPostingBackend.owoVg) {
+			return const NoCaptchaRequest();
+		}
 		if (loginSystem.isLoggedIn(Persistence.currentCookies)) {
 			return const NoCaptchaRequest();
 		}
+		return makeCaptchaRequest(board, threadId);
+	}
+
+	Chan4CustomCaptchaRequest makeCaptchaRequest(String board, int? threadId) {
 		final userAgent = captchaUserAgents[Platform.operatingSystem];
 		return Chan4CustomCaptchaRequest(
 			challengeUrl: Uri.https(sysUrl, '/captcha', {
@@ -859,6 +870,24 @@ class Site4Chan extends ImageboardSite with Http304CachingThreadMixin, Http304Ca
 	@override
 	Future<PostReceipt> submitPost(DraftPost post, CaptchaSolution captchaSolution, CancelToken cancelToken) async {
 		final encoded = await encodePostForWeb(post, captchaSolution: captchaSolution);
+		if (Settings.instance.fourChanPostingBackend == OwoVgPostingBackend.owoVg) {
+			final savedFields = owoVgLoginSystem.getSavedLoginFields();
+			if (savedFields != null) {
+				try {
+					await owoVgLoginSystem.login(savedFields, cancelToken).timeout(const Duration(seconds: 15));
+				}
+				catch (e) {
+					print('owo.vg auto-login failed: $e');
+				}
+			}
+			return OwoVgService.submitPost(
+				site: this,
+				post: post,
+				encoded: encoded,
+				captchaSolution: captchaSolution,
+				cancelToken: cancelToken
+			);
+		}
 		final file = post.file;
 		final response = await client.postUri(
 			Uri.https(sysUrl, '/${post.board}/post'),
@@ -1181,6 +1210,7 @@ class Site4Chan extends ImageboardSite with Http304CachingThreadMixin, Http304Ca
 		required this.spamFilterCaptchaDelayYellow,
 		required this.spamFilterCaptchaDelayRed,
 		required this.stickyCloudflare,
+		this.owoVgUrl = 'owo.vg',
 	}) : _alternateBaseUrl = baseUrl.contains('chan') ? baseUrl.replaceFirst('chan', 'channel') : null;
 
 	@override
@@ -1213,31 +1243,48 @@ class Site4Chan extends ImageboardSite with Http304CachingThreadMixin, Http304Ca
 	final Map<String, AsyncMemoizer<List<ImageboardBoardFlag>>> _boardFlags = {};
 	@override
 	Future<List<ImageboardBoardFlag>> getBoardFlags(String board) {
-		return _boardFlags.putIfAbsent(board, () => AsyncMemoizer<List<ImageboardBoardFlag>>()).runOnce(() async {
-			Map<String, String> flagMap = boardFlags?[board] ?? {};
-			if (boardFlags == null) {
-				// Only fetch flags if 'boardFlags' is missing in sites.json
-				try {
-					final response = await client.getUri(Uri.https(baseUrl, '/$board/'), options: Options(
-						responseType: ResponseType.plain
-					)).timeout(const Duration(seconds: 5));
-					final doc = parse(response.data);
-					flagMap = {
-						for (final e in doc.querySelector('select[name="flag"]')?.querySelectorAll('option') ?? <dom.Element>[])
-							(e.attributes['value'] ?? '0'): e.text
-					};
-				}
-				catch (e, st) {
-					print('Failed to fetch flags for $name ${formatBoardName(board)}: ${e.toStringDio()}');
-					Future.error(e, st); // crashlytics
-				}
+		final cacheKey = '${board}_${Settings.instance.fourChanPostingBackend.index}';
+		return _boardFlags.putIfAbsent(cacheKey, () => AsyncMemoizer<List<ImageboardBoardFlag>>()).runOnce(() async {
+			if (Settings.instance.fourChanPostingBackend == OwoVgPostingBackend.owoVg) {
+				return getOwoVgBoardFlags(board);
 			}
-			return flagMap.entries.map((entry) => ImageboardBoardFlag(
-				code: entry.key,
-				name: entry.value,
-				imageUrl: Uri.https(staticUrl, '/image/flags/$board/${entry.key.toLowerCase()}.gif').toString()
-			)).toList();
+			return _fetchBoardFlags(board);
 		});
+	}
+
+	Future<List<ImageboardBoardFlag>> getOwoVgBoardFlags(String board) async {
+		return _fetchBoardFlags(board, fromOwoVg: true);
+	}
+
+	Future<List<ImageboardBoardFlag>> _fetchBoardFlags(String board, {bool fromOwoVg = false}) async {
+		Map<String, String> flagMap = fromOwoVg ? {} : (boardFlags?[board] ?? {});
+		if (fromOwoVg || boardFlags == null) {
+			try {
+				final host = fromOwoVg ? owoVgUrl : baseUrl;
+				final response = await client.getUri(Uri.https(host, '/$board/'), options: Options(
+					responseType: ResponseType.plain,
+					headers: fromOwoVg ? {
+						'user-agent': OwoVgService.userAgentFor(this),
+						'origin': Uri.https(owoVgUrl).origin,
+						'referer': '${Uri.https(owoVgUrl).origin}/',
+					} : null
+				)).timeout(const Duration(seconds: 5));
+				final doc = parse(response.data);
+				flagMap = {
+					for (final e in doc.querySelector('select[name="flag"]')?.querySelectorAll('option') ?? <dom.Element>[])
+						(e.attributes['value'] ?? ''): e.text.trim().isEmpty ? 'Random flag' : e.text.trim()
+				};
+			}
+			catch (e, st) {
+				print('Failed to fetch flags for $name ${formatBoardName(board)}${fromOwoVg ? ' (owo.vg)' : ''}: ${e.toStringDio()}');
+				Future.error(e, st); // crashlytics
+			}
+		}
+		return flagMap.entries.map((entry) => ImageboardBoardFlag(
+			code: entry.key,
+			name: entry.value,
+			imageUrl: Uri.https(staticUrl, '/image/flags/$board/${entry.key.toLowerCase()}.gif').toString()
+		)).toList();
 	}
 
 	@override

--- a/lib/sites/imageboard_site.dart
+++ b/lib/sites/imageboard_site.dart
@@ -2889,6 +2889,7 @@ ImageboardSite makeSite(Map data) {
 			spamFilterCaptchaDelayYellow: Duration(milliseconds: data['spamFilterCaptchaDelayYellow'] as int? ?? 5000),
 			spamFilterCaptchaDelayRed: Duration(milliseconds: data['spamFilterCaptchaDelayRed'] as int? ?? 12000),
 			stickyCloudflare: data['stickyCloudflare'] as bool? ?? false,
+			owoVgUrl: data['owoVgUrl'] as String? ?? 'owo.vg',
 			subjectCharacterLimit: data['subjectCharacterLimit'] as int?,
 			overrideUserAgent: overrideUserAgent,
 			addIntrospectedHeaders: addIntrospectedHeaders,

--- a/lib/sites/owovg_login.dart
+++ b/lib/sites/owovg_login.dart
@@ -1,0 +1,139 @@
+import 'package:chan/services/owovg.dart';
+import 'package:chan/services/persistence.dart';
+import 'package:chan/sites/4chan.dart';
+import 'package:chan/sites/imageboard_site.dart';
+import 'package:chan/util.dart';
+import 'package:cookie_jar/cookie_jar.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+
+class SiteOwoVgGoldLoginSystem extends ImageboardSiteLoginSystem {
+	@override
+	final Site4Chan parent;
+
+	SiteOwoVgGoldLoginSystem(this.parent);
+
+	@override
+	List<ImageboardSiteLoginField> getLoginFields() {
+		return const [
+			ImageboardSiteLoginField(
+				displayName: 'Token',
+				formKey: 'owovg_id',
+				autofillHints: [AutofillHints.username]
+			),
+			ImageboardSiteLoginField(
+				displayName: 'PIN',
+				formKey: 'owovg_pin',
+				inputType: TextInputType.number,
+				autofillHints: [AutofillHints.password]
+			)
+		];
+	}
+
+	Uri get _authUri => Uri.https(parent.owoVgUrl, '/auth');
+
+	@override
+	Future<void> logoutImpl(bool fromBothWifiAndCellular, CancelToken cancelToken) async {
+		await parent.client.postUri(
+			_authUri,
+			data: {
+				'logout': '1'
+			},
+			options: Options(
+				contentType: Headers.formUrlEncodedContentType,
+				headers: {
+					'user-agent': OwoVgService.userAgentFor(parent),
+					'origin': Uri.https(parent.owoVgUrl).origin,
+					'referer': '${Uri.https(parent.owoVgUrl).origin}/',
+				},
+				extra: {
+					kPriority: RequestPriority.interactive
+				}
+			),
+			cancelToken: cancelToken
+		);
+		loggedIn[Persistence.currentCookies] = false;
+		OwoVgService.invalidateMetaCache();
+		if (fromBothWifiAndCellular) {
+			await CookieManager.instance().deleteCookies(
+				url: WebUri(parent.owoVgUrl)
+			);
+			await Persistence.nonCurrentCookies.deletePreservingCloudflare(Uri.https(parent.owoVgUrl, '/'), true);
+			loggedIn[Persistence.nonCurrentCookies] = false;
+		}
+	}
+
+	@override
+	Future<void> login(Map<ImageboardSiteLoginField, String> fields, CancelToken cancelToken) async {
+		final id = fields.entries.tryFirstWhere((e) => e.key.formKey == 'owovg_id')?.value.trim();
+		final pin = fields.entries.tryFirstWhere((e) => e.key.formKey == 'owovg_pin')?.value.trim();
+		if (id == null || pin == null) {
+			throw const ImageboardSiteLoginException('Token and PIN are required');
+		}
+		final response = await parent.client.postUri(
+			_authUri,
+			data: {
+				'id': id,
+				'pin': pin,
+				'long_login': '1',
+			},
+			options: Options(
+				responseType: ResponseType.plain,
+				contentType: Headers.formUrlEncodedContentType,
+				validateStatus: (status) => status != null && status < 500,
+				headers: {
+					'user-agent': OwoVgService.userAgentFor(parent),
+					'origin': Uri.https(parent.owoVgUrl).origin,
+					'referer': '${Uri.https(parent.owoVgUrl).origin}/auth',
+				},
+				extra: {
+					kPriority: RequestPriority.interactive
+				}
+			),
+			cancelToken: cancelToken
+		);
+		final body = response.data as String? ?? '';
+		if (response.statusCode != 200) {
+			loggedIn[Persistence.currentCookies] = false;
+			await logout(false, cancelToken);
+			throw ImageboardSiteLoginException(body.trim().isEmpty ? 'Login failed (${response.statusCode})' : body.trim());
+		}
+		if (!body.contains('Success!')) {
+			loggedIn[Persistence.currentCookies] = false;
+			await logout(false, cancelToken);
+			throw ImageboardSiteLoginException(body.trim().isEmpty ? 'Login failed' : body.trim());
+		}
+		loggedIn[Persistence.currentCookies] = true;
+		OwoVgService.invalidateMetaCache();
+		try {
+			final meta = await OwoVgService.fetchMeta(parent, forceRefresh: true);
+			if (!meta.gold) {
+				loggedIn[Persistence.currentCookies] = false;
+				throw const ImageboardSiteLoginException('Logged in but gold status not detected');
+			}
+		}
+		catch (e) {
+			if (e is ImageboardSiteLoginException) {
+				rethrow;
+			}
+		}
+	}
+
+	@override
+	String get name => 'owo.vg Gold Pass';
+
+	@override
+	Uri? get iconUrl => Uri.https(parent.staticUrl, '/image/minileaf.gif');
+
+	@override
+	bool get hidden => false;
+
+	@override
+	bool isLoggedIn(CookieJar jar) {
+		if (loggedIn[jar] == true) {
+			return true;
+		}
+		return getSavedLoginFields() != null;
+	}
+}

--- a/lib/widgets/captcha_4chan.dart
+++ b/lib/widgets/captcha_4chan.dart
@@ -300,43 +300,15 @@ Future<Captcha4ChanCustomChallenge> requestCaptcha4ChanCustomChallenge({
 		final challenge = data['challenge'] as String;
 		final lifetime = Duration(seconds: (data['ttl'] as num).toInt());
 		if (data['tasks'] case List rawTasks) {
-			final tasks = <Captcha4ChanCustomChallengeTasksTask>[];
-			for (final rawTask in rawTasks) {
-				final choices = <ui.Image>[];
-				for (final item in (rawTask as Map)['items'] as List) {
-					final completer = Completer<ui.Image>();
-					Base64ImageProvider(item as String).resolve(const ImageConfiguration()).addListener(ImageStreamListener((info, isSynchronous) {
-						completer.complete(info.image);
-					}, onError: (e, st) {
-						completer.completeError(e, st);
-					}));
-					choices.add(await completer.future);
-				}
-				if (rawTask['str'] case String str) {
-					tasks.add((choices: choices, question: _buildQuestion(str)));
-				}
-				else if (rawTask['img'] case String img) {
-					tasks.add((choices: choices, question: ConstrainedBox(
-						constraints: const BoxConstraints(
-							minWidth: 100,
-							minHeight: 100
-						),
-						child: Image(
-							image: Base64ImageProvider(img),
-							fit: BoxFit.contain
-						)
-					)));
-				}
-			}
-			return Captcha4ChanCustomChallengeTasks(
+			return buildCaptcha4ChanCustomChallengeTasks(
 				request: request,
 				challenge: challenge,
+				rawTasks: rawTasks,
 				acquiredAt: acquiredAt,
 				tryAgainAt: tryAgainAt,
 				lifetime: lifetime,
 				cloudflare: challengeResponse.cloudflare,
-				originalData: data,
-				tasks: tasks
+				originalData: data
 			);
 		}
 		Completer<ui.Image>? foregroundImageCompleter;
@@ -372,6 +344,60 @@ Future<Captcha4ChanCustomChallenge> requestCaptcha4ChanCustomChallenge({
 			originalData: data
 		);
 	});
+}
+
+Future<Captcha4ChanCustomChallengeTasks> buildCaptcha4ChanCustomChallengeTasks({
+	required Chan4CustomCaptchaRequest request,
+	required String challenge,
+	required List rawTasks,
+	required DateTime acquiredAt,
+	required DateTime? tryAgainAt,
+	required Duration lifetime,
+	required bool cloudflare,
+	required Map originalData,
+	List<int?> taskHints = const [],
+	bool autoApplyHints = false
+}) async {
+	final tasks = <Captcha4ChanCustomChallengeTasksTask>[];
+	for (final rawTask in rawTasks) {
+		final choices = <ui.Image>[];
+		for (final item in (rawTask as Map)['items'] as List) {
+			final completer = Completer<ui.Image>();
+			Base64ImageProvider(item as String).resolve(const ImageConfiguration()).addListener(ImageStreamListener((info, isSynchronous) {
+				completer.complete(info.image);
+			}, onError: (e, st) {
+				completer.completeError(e, st);
+			}));
+			choices.add(await completer.future);
+		}
+		if (rawTask['str'] case String str) {
+			tasks.add((choices: choices, question: _buildQuestion(str)));
+		}
+		else if (rawTask['img'] case String img) {
+			tasks.add((choices: choices, question: ConstrainedBox(
+				constraints: const BoxConstraints(
+					minWidth: 100,
+					minHeight: 100
+				),
+				child: Image(
+					image: Base64ImageProvider(img),
+					fit: BoxFit.contain
+				)
+			)));
+		}
+	}
+	return Captcha4ChanCustomChallengeTasks(
+		request: request,
+		challenge: challenge,
+		acquiredAt: acquiredAt,
+		tryAgainAt: tryAgainAt,
+		lifetime: lifetime,
+		cloudflare: cloudflare,
+		originalData: originalData,
+		tasks: tasks,
+		taskHints: taskHints,
+		autoApplyHints: autoApplyHints
+	);
 }
 
 Future<int> _alignImage(Captcha4ChanCustomChallengeText challenge) async {
@@ -824,6 +850,7 @@ class Captcha4ChanCustom extends StatefulWidget {
 	final Captcha4ChanCustomChallenge? initialChallenge;
 	final (Object, StackTrace)? initialChallengeException;
 	final ValueChanged<DateTime>? onTryAgainAt;
+	final bool allowChallengeRefresh;
 
 	const Captcha4ChanCustom({
 		required this.site,
@@ -833,6 +860,7 @@ class Captcha4ChanCustom extends StatefulWidget {
 		this.initialChallenge,
 		this.initialChallengeException,
 		this.onTryAgainAt,
+		this.allowChallengeRefresh = true,
 		Key? key
 	}) : super(key: key);
 
@@ -950,6 +978,8 @@ typedef Captcha4ChanCustomChallengeTasksTask = ({List<ui.Image> choices, Widget 
 
 class Captcha4ChanCustomChallengeTasks extends Captcha4ChanCustomChallenge {
 	final List<Captcha4ChanCustomChallengeTasksTask> tasks;
+	final List<int?> taskHints;
+	final bool autoApplyHints;
 	({List<int?> taskChoices, List<bool> collapseTasks})? _wipAnswer;
 
 	Captcha4ChanCustomChallengeTasks({
@@ -960,7 +990,9 @@ class Captcha4ChanCustomChallengeTasks extends Captcha4ChanCustomChallenge {
 		required super.lifetime,
 		required super.cloudflare,
 		required super.originalData,
-		required this.tasks
+		required this.tasks,
+		this.taskHints = const [],
+		this.autoApplyHints = false
 	});
 
 	@override
@@ -1034,6 +1066,7 @@ class _Captcha4ChanCustomState extends State<Captcha4ChanCustom> {
 	final Map<Chan4CustomCaptchaLetterKey, _PickerStuff> _pickerStuff = {};
 	final List<_PickerStuff> _orphanPickerStuff = [];
 	List<int?> _taskChoices = [];
+	List<int?> _taskHints = [];
 	List<bool> _collapseTasks = [];
 	bool _cloudGuessFailed = false;
 	String? _lastCloudGuess;
@@ -1253,6 +1286,9 @@ class _Captcha4ChanCustomState extends State<Captcha4ChanCustom> {
 			}
 		}
 		else if (challenge case Captcha4ChanCustomChallengeTasks challenge) {
+			_taskHints = challenge.taskHints.length == challenge.tasks.length
+				? challenge.taskHints.toList()
+				: List.filled(challenge.tasks.length, null);
 			if (challenge._wipAnswer case final wip? when wip.collapseTasks.length == challenge.tasks.length &&
 																										wip.taskChoices.length == challenge.tasks.length
 			) {
@@ -1261,10 +1297,35 @@ class _Captcha4ChanCustomState extends State<Captcha4ChanCustom> {
 			}
 			else {
 				_taskChoices = List.filled(challenge.tasks.length, null);
+				if (challenge.autoApplyHints) {
+					for (var i = 0; i < _taskChoices.length; i++) {
+						_taskChoices[i] = _taskHints[i];
+					}
+				}
 				_collapseTasks = List.filled(challenge.tasks.length, false);
 			}
 			setState(() {});
 		}
+	}
+
+	BoxDecoration _taskChoiceDecoration(int taskIndex, int choiceIndex) {
+		final selected = _taskChoices[taskIndex] == choiceIndex;
+		final hinted = taskIndex < _taskHints.length && _taskHints[taskIndex] == choiceIndex;
+		if (selected) {
+			return BoxDecoration(
+				border: Border.all(color: const Color(0xFFADFF2F), width: 3),
+				borderRadius: BorderRadius.circular(4)
+			);
+		}
+		if (hinted) {
+			return BoxDecoration(
+				border: Border.all(color: Colors.orange, width: 3),
+				borderRadius: BorderRadius.circular(4)
+			);
+		}
+		return const BoxDecoration(
+			borderRadius: BorderRadius.all(Radius.circular(4))
+		);
 	}
 
 	String _previousText = "000000";
@@ -1397,6 +1458,9 @@ class _Captcha4ChanCustomState extends State<Captcha4ChanCustom> {
 	}
 
 	Widget _cooldownedRetryButton(BuildContext context) {
+		if (!widget.allowChallengeRefresh) {
+			return const SizedBox.shrink();
+		}
 		if (tryAgainAt != null) {
 			return TimedRebuilder(
 				interval: () => const Duration(seconds: 1),
@@ -1953,10 +2017,7 @@ class _Captcha4ChanCustomState extends State<Captcha4ChanCustom> {
 														},
 														child: Container(
 															padding: const EdgeInsets.all(8),
-															decoration: BoxDecoration(
-																color: _taskChoices[task.$1] == choice.$1 ? theme.primaryColorWithBrightness(0.7) : null,
-																borderRadius: const BorderRadius.all(Radius.circular(4)),
-															),
+															decoration: _taskChoiceDecoration(task.$1, choice.$1),
 															constraints: const BoxConstraints(
 																minWidth: 100,
 																minHeight: 100
@@ -2001,10 +2062,7 @@ class _Captcha4ChanCustomState extends State<Captcha4ChanCustom> {
 																padding: activeSingleChoice ? const EdgeInsets.only(bottom: 8) : EdgeInsets.zero,
 																child: Container(
 																	padding: const EdgeInsets.symmetric(horizontal: 8),
-																	decoration: BoxDecoration(
-																		color: _taskChoices[task.$1] == choice.$1 ? theme.primaryColorWithBrightness(0.7) : null,
-																		borderRadius: const BorderRadius.all(Radius.circular(4)),
-																	),
+																	decoration: _taskChoiceDecoration(task.$1, choice.$1),
 																	child: Column(
 																		mainAxisSize: MainAxisSize.min,
 																		children: [

--- a/lib/widgets/html_rich_text.dart
+++ b/lib/widgets/html_rich_text.dart
@@ -1,0 +1,118 @@
+import 'package:chan/services/launch_url_externally.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:html/dom.dart' as dom;
+import 'package:html/parser.dart' show parseFragment;
+
+bool containsHtml(String text) => RegExp(r'<\s*[a-zA-Z][^>]*>').hasMatch(text);
+
+Uri resolveHtmlLinkHref(String href, {String baseOrigin = 'https://owo.vg'}) {
+	final trimmed = href.trim();
+	if (trimmed.isEmpty) {
+		return Uri.parse(baseOrigin);
+	}
+	final uri = Uri.tryParse(trimmed);
+	if (uri != null && uri.hasScheme) {
+		return uri;
+	}
+	if (trimmed.startsWith('//')) {
+		return Uri.parse('https:$trimmed');
+	}
+	if (trimmed.startsWith('/')) {
+		return Uri.parse('$baseOrigin$trimmed');
+	}
+	return Uri.parse(trimmed);
+}
+
+class HtmlRichText extends StatefulWidget {
+	final String html;
+	final TextStyle? style;
+	final TextStyle? linkStyle;
+	final String linkBaseOrigin;
+	const HtmlRichText({
+		required this.html,
+		this.style,
+		this.linkStyle,
+		this.linkBaseOrigin = 'https://owo.vg',
+		super.key
+	});
+
+	@override
+	State<HtmlRichText> createState() => _HtmlRichTextState();
+}
+
+class _HtmlRichTextState extends State<HtmlRichText> {
+	final _recognizers = <TapGestureRecognizer>[];
+
+	@override
+	void dispose() {
+		for (final recognizer in _recognizers) {
+			recognizer.dispose();
+		}
+		super.dispose();
+	}
+
+	TapGestureRecognizer _linkRecognizer(String href) {
+		final recognizer = TapGestureRecognizer()
+			..onTap = () => launchUrlExternally(resolveHtmlLinkHref(href, baseOrigin: widget.linkBaseOrigin));
+		_recognizers.add(recognizer);
+		return recognizer;
+	}
+
+	List<InlineSpan> _buildSpans(List<dom.Node> nodes, TextStyle linkStyle) {
+		final spans = <InlineSpan>[];
+		for (final node in nodes) {
+			if (node is dom.Text) {
+				final text = node.text;
+				if (text.isNotEmpty) {
+					spans.add(TextSpan(text: text));
+				}
+			}
+			else if (node is dom.Element) {
+				switch (node.localName) {
+					case 'a':
+						final href = node.attributes['href']?.trim();
+						final childSpans = _buildSpans(node.nodes, linkStyle);
+						if (href != null && href.isNotEmpty && childSpans.isNotEmpty) {
+							spans.add(TextSpan(
+								style: linkStyle,
+								recognizer: _linkRecognizer(href),
+								children: childSpans
+							));
+						}
+						else {
+							spans.addAll(childSpans);
+						}
+					case 'br':
+						spans.add(const TextSpan(text: '\n'));
+					case 'span':
+					case 'p':
+					case 'b':
+					case 'strong':
+					case 'i':
+					case 'em':
+						spans.addAll(_buildSpans(node.nodes, linkStyle));
+					default:
+						spans.addAll(_buildSpans(node.nodes, linkStyle));
+				}
+			}
+		}
+		return spans;
+	}
+
+	@override
+	Widget build(BuildContext context) {
+		final baseStyle = widget.style ?? DefaultTextStyle.of(context).style;
+		final linkStyle = widget.linkStyle ?? baseStyle.copyWith(
+			color: Theme.of(context).colorScheme.primary,
+			decoration: TextDecoration.underline
+		);
+		final spans = _buildSpans(parseFragment(widget.html).nodes, linkStyle);
+		if (spans.isEmpty) {
+			return Text(widget.html, style: baseStyle);
+		}
+		return SelectableText.rich(
+			TextSpan(style: baseStyle, children: spans)
+		);
+	}
+}

--- a/lib/widgets/owovg_captcha.dart
+++ b/lib/widgets/owovg_captcha.dart
@@ -1,0 +1,181 @@
+import 'dart:convert';
+
+import 'package:chan/pages/overscroll_modal.dart';
+import 'package:chan/sites/4chan.dart';
+import 'package:chan/sites/imageboard_site.dart';
+import 'package:chan/widgets/captcha_4chan.dart';
+import 'package:chan/widgets/util.dart';
+import 'package:flutter/material.dart';
+import 'package:html/parser.dart' show parse;
+
+typedef OwoVgWsSend = void Function(Map<String, dynamic> payload);
+
+class OwoVgInteractiveCaptcha {
+	final String challenge;
+	final List<Map<String, dynamic>> tasks;
+	final Duration lifetime;
+	final String solutionString;
+	final bool suggestOnly;
+	const OwoVgInteractiveCaptcha({
+		required this.challenge,
+		required this.tasks,
+		required this.lifetime,
+		required this.solutionString,
+		required this.suggestOnly
+	});
+}
+
+OwoVgInteractiveCaptcha? parseOwoVgInteractiveCaptchaHtml(String html) {
+	final document = parse(html);
+	final challenge = document.querySelector('input[name="t-challenge"]')?.attributes['value']?.trim();
+	if (challenge == null || challenge.isEmpty) {
+		return null;
+	}
+	final tasks = _extractTasksJson(html);
+	if (tasks == null || tasks.isEmpty) {
+		return null;
+	}
+	final solutionString = _extractSolutionString(html) ?? List.filled(tasks.length, '_').join();
+	return OwoVgInteractiveCaptcha(
+		challenge: challenge,
+		tasks: tasks,
+		lifetime: _extractLifetime(html),
+		solutionString: solutionString,
+		suggestOnly: _extractSuggestOnly(html)
+	);
+}
+
+List<Map<String, dynamic>>? _extractTasksJson(String html) {
+	const prefix = 'const tasks = ';
+	final start = html.indexOf(prefix);
+	if (start == -1) {
+		return null;
+	}
+	var index = start + prefix.length;
+	while (index < html.length && html[index].trim().isEmpty) {
+		index++;
+	}
+	if (index >= html.length || html[index] != '[') {
+		return null;
+	}
+	var depth = 0;
+	final begin = index;
+	for (; index < html.length; index++) {
+		final char = html[index];
+		if (char == '[') {
+			depth++;
+		}
+		else if (char == ']') {
+			depth--;
+			if (depth == 0) {
+				final decoded = jsonDecode(html.substring(begin, index + 1));
+				if (decoded is! List) {
+					return null;
+				}
+				return decoded.cast<Map>().map((task) => Map<String, dynamic>.from(task)).toList();
+			}
+		}
+	}
+	return null;
+}
+
+String? _extractSolutionString(String html) {
+	final match = RegExp(r"const solutionString = '([^']*)'").firstMatch(html);
+	return match?.group(1);
+}
+
+bool _extractSuggestOnly(String html) {
+	final match = RegExp(r'const suggestOnly = (true|false)').firstMatch(html);
+	return match?.group(1) == 'true';
+}
+
+List<int?> taskHintsFromSolutionString(String solutionString, int taskCount) {
+	return [
+		for (var i = 0; i < taskCount; i++)
+			if (i < solutionString.length && solutionString[i] != '_')
+				int.tryParse(solutionString[i])
+			else
+				null
+	];
+}
+
+Duration _extractLifetime(String html) {
+	final timMatch = RegExp(r'let tim = (\d+)').firstMatch(html);
+	if (timMatch case final match?) {
+		final ms = int.tryParse(match.group(1)!);
+		if (ms != null && ms > 0) {
+			return Duration(milliseconds: ms);
+		}
+	}
+	final timeoutMatch = RegExp(r'setTimeout\([^,]+,\s*(\d+)\)').firstMatch(html);
+	if (timeoutMatch case final match?) {
+		final ms = int.tryParse(match.group(1)!);
+		if (ms != null && ms > 0) {
+			return Duration(milliseconds: ms);
+		}
+	}
+	return const Duration(minutes: 2);
+}
+
+Future<bool> showOwoVgCaptchaDialog({
+	required BuildContext context,
+	required Site4Chan site,
+	required Chan4CustomCaptchaRequest request,
+	required String html,
+	required OwoVgWsSend sendMessage
+}) async {
+	final parsed = parseOwoVgInteractiveCaptchaHtml(html);
+	if (parsed == null) {
+		return false;
+	}
+	final acquiredAt = DateTime.now();
+	final taskHints = taskHintsFromSolutionString(parsed.solutionString, parsed.tasks.length);
+	final autoApplyHints = !parsed.suggestOnly && !parsed.solutionString.contains('_');
+	final challenge = await buildCaptcha4ChanCustomChallengeTasks(
+		request: request,
+		challenge: parsed.challenge,
+		rawTasks: parsed.tasks,
+		acquiredAt: acquiredAt,
+		tryAgainAt: null,
+		lifetime: parsed.lifetime,
+		cloudflare: false,
+		taskHints: taskHints,
+		autoApplyHints: autoApplyHints,
+		originalData: {
+			'source': 'owovg',
+			'challenge': parsed.challenge,
+			'tasks': parsed.tasks,
+			'solutionString': parsed.solutionString,
+			'suggestOnly': parsed.suggestOnly,
+		}
+	);
+	if (!context.mounted) {
+		challenge.dispose();
+		return false;
+	}
+	final solved = await Navigator.of(context, rootNavigator: true).push<bool>(TransparentRoute(
+		builder: (dialogContext) => OverscrollModalPage(
+			increasePopDifficulty: true,
+			child: Captcha4ChanCustom(
+				site: site,
+				request: request,
+				initialChallenge: challenge,
+				allowChallengeRefresh: false,
+				onCaptchaSolved: (solution) {
+					if (solution != null) {
+						sendMessage({
+							't': 'solve',
+							't-response': solution.response,
+							't-challenge': solution.challenge,
+						});
+					}
+					Navigator.of(dialogContext).pop(solution != null);
+				}
+			)
+		)
+	));
+	if (solved != true) {
+		challenge.dispose();
+	}
+	return solved ?? false;
+}

--- a/lib/widgets/owovg_captcha.dart
+++ b/lib/widgets/owovg_captcha.dart
@@ -117,6 +117,14 @@ Duration _extractLifetime(String html) {
 	return const Duration(minutes: 2);
 }
 
+bool isOwoVgEmailInteractiveCaptcha(String html) {
+	return html.contains("'solve_email'") || html.contains('"solve_email"');
+}
+
+String owoVgInteractiveCaptchaSolveType(String html) {
+	return isOwoVgEmailInteractiveCaptcha(html) ? 'solve_email' : 'solve';
+}
+
 Future<bool> showOwoVgCaptchaDialog({
 	required BuildContext context,
 	required Site4Chan site,
@@ -153,6 +161,7 @@ Future<bool> showOwoVgCaptchaDialog({
 		challenge.dispose();
 		return false;
 	}
+	final solveType = owoVgInteractiveCaptchaSolveType(html);
 	final solved = await Navigator.of(context, rootNavigator: true).push<bool>(TransparentRoute(
 		builder: (dialogContext) => OverscrollModalPage(
 			increasePopDifficulty: true,
@@ -164,7 +173,7 @@ Future<bool> showOwoVgCaptchaDialog({
 				onCaptchaSolved: (solution) {
 					if (solution != null) {
 						sendMessage({
-							't': 'solve',
+							't': solveType,
 							't-response': solution.response,
 							't-challenge': solution.challenge,
 						});

--- a/lib/widgets/owovg_hcaptcha.dart
+++ b/lib/widgets/owovg_hcaptcha.dart
@@ -1,0 +1,244 @@
+import 'dart:convert';
+import 'dart:math' as math;
+
+import 'package:chan/widgets/adaptive.dart';
+import 'package:chan/widgets/owovg_captcha.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+
+class OwoVgEmailHcaptchaPrompt {
+	final String title;
+	final String sitekey;
+	final String nonce;
+	final String? pageHtml;
+	final bool report;
+	const OwoVgEmailHcaptchaPrompt({
+		required this.title,
+		required this.sitekey,
+		required this.nonce,
+		this.pageHtml,
+		this.report = false
+	});
+
+	factory OwoVgEmailHcaptchaPrompt.fromJson(Map json) => OwoVgEmailHcaptchaPrompt(
+		title: json['title'] as String? ?? 'hCAPTCHA',
+		sitekey: json['sitekey'] as String? ?? '',
+		nonce: json['nonce'] as String? ?? '',
+		pageHtml: json['html'] as String?,
+		report: json['report'] as bool? ?? false
+	);
+
+	bool get isValid => sitekey.isNotEmpty && nonce.isNotEmpty;
+}
+
+bool isValidOwoVgHcaptchaToken(String token) {
+	return token.startsWith('P1_') || token.startsWith('F1_');
+}
+
+String _buildEmailHcaptchaHtml(OwoVgEmailHcaptchaPrompt prompt) {
+	final formId = 'hcap_${DateTime.now().microsecondsSinceEpoch}';
+	final pageHtmlB64 = base64Encode(utf8.encode(prompt.pageHtml ?? ''));
+	final sitekeyJson = jsonEncode(prompt.sitekey);
+	final nonceJson = jsonEncode(prompt.nonce);
+	final pageHtmlB64Json = jsonEncode(pageHtmlB64);
+	return '''
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+html, body {
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  overflow-x: hidden;
+}
+#hcap-root-$formId {
+  width: 100%;
+  max-width: 520px;
+  font-family: sans-serif;
+  box-sizing: border-box;
+}
+#hcap-widget-$formId {
+  min-height: 420px;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 8px 0;
+  box-sizing: border-box;
+}
+#hcap-frame-$formId {
+  width: 0;
+  height: 0;
+  border: 0;
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+</style>
+</head>
+<body>
+<div id="hcap-root-$formId">
+  <iframe id="hcap-frame-$formId" sandbox="allow-scripts allow-same-origin"></iframe>
+  <div id="hcap-widget-$formId"></div>
+</div>
+<script>
+(() => {
+  const formId = ${jsonEncode(formId)};
+  const nonce = $nonceJson;
+  const sitekey = $sitekeyJson;
+  const pageHtml = $pageHtmlB64Json.length ? atob($pageHtmlB64Json) : '';
+  let done = false;
+
+  const submitToken = (token) => {
+    if (done || !token || typeof token !== 'string') return;
+    if (!token.startsWith('P1_') && !token.startsWith('F1_')) return;
+    done = true;
+    if (window.flutter_inappwebview && window.flutter_inappwebview.callHandler) {
+      window.flutter_inappwebview.callHandler('owoVgHcaptchaDone', token);
+    }
+  };
+
+  const iframe = document.getElementById('hcap-frame-' + formId);
+  if (iframe && pageHtml) {
+    iframe.src = URL.createObjectURL(new Blob([pageHtml], { type: 'text/html;charset=utf-8' }));
+  }
+
+  window.addEventListener('message', (ev) => {
+    const data = ev.data;
+    if (!data || typeof data !== 'object') return;
+    if (data.t === 'solve_email_hcaptcha') {
+      submitToken(data.token || data['h-captcha-response']);
+    }
+  }, true);
+
+  window.pcd_c_done = submitToken;
+  window.pcd_c_loaded = () => {
+    if (done || !window.hcaptcha || !sitekey) return;
+    try {
+      window.hcaptcha.render('hcap-widget-' + formId, {
+        sitekey: sitekey,
+        callback: 'pcd_c_done',
+      });
+    } catch (err) {
+      console.error('hCaptcha render failed', err);
+    }
+  };
+
+  if (sitekey) {
+    const script = document.createElement('script');
+    script.src = 'https://js.hcaptcha.com/1/api.js?onload=pcd_c_loaded&render=explicit&recaptchacompat=off';
+    script.async = true;
+    script.defer = true;
+    script.onerror = () => console.error('failed to load hCaptcha script');
+    document.head.appendChild(script);
+  }
+})();
+</script>
+</body>
+</html>
+''';
+}
+
+Future<bool> showOwoVgEmailHcaptchaDialog({
+	required BuildContext context,
+	required OwoVgEmailHcaptchaPrompt prompt,
+	required OwoVgWsSend sendMessage
+}) async {
+	if (!prompt.isValid) {
+		return false;
+	}
+	final size = MediaQuery.sizeOf(context);
+	final width = math.min(520.0, size.width - 24);
+	final height = math.min(520.0, size.height * 0.75);
+	return await showAdaptiveDialog<bool>(
+		context: context,
+		barrierDismissible: false,
+		builder: (dialogContext) => AdaptiveAlertDialog(
+			title: Text(prompt.title),
+			content: SizedBox(
+				width: width,
+				height: height,
+				child: OwoVgEmailHcaptchaWebView(
+					prompt: prompt,
+					onSolved: (token) {
+						sendMessage({
+							't': 'solve_email_hcaptcha',
+							'h-captcha-response': token,
+							't-challenge': prompt.nonce,
+							'sitekey': prompt.sitekey,
+						});
+						Navigator.of(dialogContext).pop(true);
+					}
+				)
+			),
+			actions: [
+				AdaptiveDialogAction(
+					child: const Text('Cancel'),
+					onPressed: () => Navigator.of(dialogContext).pop(false)
+				)
+			]
+		)
+	) ?? false;
+}
+
+class OwoVgEmailHcaptchaWebView extends StatefulWidget {
+	final OwoVgEmailHcaptchaPrompt prompt;
+	final ValueChanged<String> onSolved;
+	const OwoVgEmailHcaptchaWebView({
+		required this.prompt,
+		required this.onSolved,
+		super.key
+	});
+
+	@override
+	State<OwoVgEmailHcaptchaWebView> createState() => _OwoVgEmailHcaptchaWebViewState();
+}
+
+class _OwoVgEmailHcaptchaWebViewState extends State<OwoVgEmailHcaptchaWebView> {
+	static final _pageUrl = WebUri('https://owo.vg/');
+	var _solved = false;
+
+	@override
+	Widget build(BuildContext context) {
+		return InAppWebView(
+			initialData: InAppWebViewInitialData(
+				data: _buildEmailHcaptchaHtml(widget.prompt),
+				baseUrl: _pageUrl,
+				mimeType: 'text/html',
+				encoding: 'utf-8'
+			),
+			initialSettings: InAppWebViewSettings(
+				javaScriptEnabled: true,
+				domStorageEnabled: true,
+				mediaPlaybackRequiresUserGesture: false,
+				transparentBackground: true,
+				useWideViewPort: true,
+				verticalScrollBarEnabled: true,
+				disableVerticalScroll: false,
+				supportMultipleWindows: true,
+				javaScriptCanOpenWindowsAutomatically: true,
+				overScrollMode: OverScrollMode.IF_CONTENT_SCROLLS
+			),
+			onWebViewCreated: (controller) {
+				controller.addJavaScriptHandler(
+					handlerName: 'owoVgHcaptchaDone',
+					callback: (args) {
+						if (_solved || args.isEmpty) {
+							return;
+						}
+						final raw = args.first;
+						if (raw is! String || !isValidOwoVgHcaptchaToken(raw)) {
+							return;
+						}
+						_solved = true;
+						if (mounted) {
+							widget.onSolved(raw);
+						}
+					}
+				);
+			},
+		);
+	}
+}

--- a/lib/widgets/owovg_reply_extras.dart
+++ b/lib/widgets/owovg_reply_extras.dart
@@ -1,0 +1,370 @@
+import 'package:chan/models/owovg_post_extras.dart';
+import 'package:chan/pages/cookie_browser.dart';
+import 'package:chan/services/owovg.dart';
+import 'package:chan/services/settings.dart';
+import 'package:chan/sites/4chan.dart';
+import 'package:chan/services/util.dart';
+import 'package:chan/util.dart';
+import 'package:chan/widgets/adaptive.dart';
+import 'package:chan/widgets/html_rich_text.dart';
+import 'package:chan/widgets/util.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+class OwoVgReplyExtrasPanel extends StatefulWidget {
+	final Site4Chan site;
+	final String board;
+	final OwoVgPostExtras extras;
+	final ValueChanged<OwoVgPostExtras> onChanged;
+	const OwoVgReplyExtrasPanel({
+		required this.site,
+		required this.board,
+		required this.extras,
+		required this.onChanged,
+		super.key
+	});
+
+	@override
+	State<OwoVgReplyExtrasPanel> createState() => _OwoVgReplyExtrasPanelState();
+}
+
+class _OwoVgReplyExtrasPanelState extends State<OwoVgReplyExtrasPanel> {
+	OwoVgMeta? _meta;
+	bool _loadingMeta = true;
+	List<(String, String)> _recycleIpOptions = const [];
+	final _peeTextController = TextEditingController();
+
+	@override
+	void initState() {
+		super.initState();
+		_peeTextController.text = widget.extras.peeText ?? '';
+		_loadMeta();
+	}
+
+	@override
+	void didUpdateWidget(OwoVgReplyExtrasPanel oldWidget) {
+		super.didUpdateWidget(oldWidget);
+		if (oldWidget.board != widget.board) {
+			_loadMeta();
+		}
+		if (oldWidget.extras.peeText != widget.extras.peeText) {
+			_peeTextController.text = widget.extras.peeText ?? '';
+		}
+	}
+
+	@override
+	void dispose() {
+		_peeTextController.dispose();
+		super.dispose();
+	}
+
+	Future<void> _loadMeta() async {
+		setState(() => _loadingMeta = true);
+		try {
+			final meta = await OwoVgService.fetchMeta(widget.site, board: widget.board);
+			if (!mounted) return;
+			setState(() {
+				_meta = meta;
+				_recycleIpOptions = OwoVgService.parseRecycleIpOptions(meta.ipMarkup);
+				_loadingMeta = false;
+			});
+		}
+		catch (e) {
+			if (!mounted) return;
+			setState(() => _loadingMeta = false);
+		}
+	}
+
+	void _update(OwoVgPostExtras extras) => widget.onChanged(extras);
+
+	Future<void> _pickPeeFiles() async {
+		final result = await FilePicker.platform.pickFiles(allowMultiple: true);
+		if (result == null) return;
+		final paths = result.paths.whereType<String>().toList();
+		if (paths.isEmpty) return;
+		_update(widget.extras.copyWith(peeFiles: [...widget.extras.peeFiles, ...paths].take(16).toList()));
+	}
+
+	Future<void> _pickFakeThumbnail() async {
+		final result = await FilePicker.platform.pickFiles(allowMultiple: false);
+		final path = result?.files.single.path;
+		if (path == null) return;
+		_update(widget.extras.copyWith(fakeThumbnail: path));
+	}
+
+	Future<void> _complain() async {
+		final controller = TextEditingController();
+		final message = await showAdaptiveDialog<String>(
+			context: context,
+			builder: (context) => AdaptiveAlertDialog(
+				title: const Text('Complain'),
+				content: TextField(
+					controller: controller,
+					maxLines: 4,
+					autocorrect: false,
+					decoration: const InputDecoration(
+						hintText: 'Complain about owo.vg bugs and posting issues here.'
+					)
+				),
+				actions: [
+					AdaptiveDialogAction(
+						child: const Text('Cancel'),
+						onPressed: () => Navigator.pop(context)
+					),
+					AdaptiveDialogAction(
+						child: const Text('Send'),
+						onPressed: () => Navigator.pop(context, controller.text)
+					)
+				]
+			)
+		);
+		controller.dispose();
+		if (message == null || !mounted) return;
+		try {
+			final response = await OwoVgService.submitFeedback(widget.site, message);
+			if (!mounted) return;
+			showToast(context: context, message: response, icon: CupertinoIcons.checkmark_circle);
+		}
+		catch (e) {
+			if (!mounted) return;
+			showToast(context: context, message: e.toString(), icon: CupertinoIcons.exclamationmark_triangle);
+		}
+	}
+
+	@override
+	Widget build(BuildContext context) {
+		final settings = context.watch<Settings>();
+		final useOwoVg = settings.fourChanPostingBackend == OwoVgPostingBackend.owoVg;
+		final gold = _meta?.gold ?? false;
+		final skipAutosolverLabel = gold ? 'Manual captcha' : 'Skip autosolver';
+		return Column(
+			crossAxisAlignment: CrossAxisAlignment.stretch,
+			children: [
+				Padding(
+					padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+					child: Column(
+						crossAxisAlignment: CrossAxisAlignment.stretch,
+						children: [
+							const Text('Posting backend', style: TextStyle(fontWeight: FontWeight.w600)),
+							const SizedBox(height: 8),
+							AdaptiveSegmentedControl<OwoVgPostingBackend>(
+								groupValue: settings.fourChanPostingBackend,
+								fillWidth: true,
+								padding: EdgeInsets.zero,
+								onValueChanged: (backend) {
+									settings.fourChanPostingBackend = backend;
+									setState(() {});
+								},
+								children: const {
+									OwoVgPostingBackend.direct: (null, '4chan'),
+									OwoVgPostingBackend.owoVg: (null, 'owo.vg'),
+								}
+							),
+							if (useOwoVg) ...[
+								const SizedBox(height: 12),
+								const Text('Pool', style: TextStyle(fontWeight: FontWeight.w600)),
+								const SizedBox(height: 8),
+								AdaptiveSegmentedControl<String>(
+									groupValue: settings.owoVgPool,
+									fillWidth: true,
+									padding: EdgeInsets.zero,
+									onValueChanged: (pool) {
+										settings.owoVgPool = pool;
+										setState(() {});
+									},
+									children: const {
+										's': (null, 'Shitposting'),
+										'l': (null, 'Legitposting'),
+										'c': (null, '😭'),
+									}
+								),
+							]
+							else const Padding(
+								padding: EdgeInsets.only(top: 12),
+								child: Text(
+									'Posts go directly to 4chan.',
+									style: TextStyle(fontSize: 13)
+								)
+							),
+						]
+					)
+				),
+				if (_loadingMeta)
+					const Padding(
+						padding: EdgeInsets.all(8),
+						child: Center(child: CupertinoActivityIndicator())
+					),
+				if (_meta?.news case final news? when news.trim().isNotEmpty)
+					Padding(
+						padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+						child: HtmlRichText(
+							html: news,
+							style: TextStyle(color: Colors.red.shade700, fontSize: 13),
+							linkStyle: TextStyle(
+								color: Colors.red.shade700,
+								fontSize: 13,
+								decoration: TextDecoration.underline
+							)
+						)
+					),
+				if (!useOwoVg)
+					const SizedBox(height: 8)
+				else ...[
+				Wrap(
+					spacing: 8,
+					runSpacing: 8,
+					children: [
+						AdaptiveThinButton(
+							onPressed: _complain,
+							child: const Text('Complain')
+						),
+						if (gold) AdaptiveThinButton(
+							onPressed: () => openCookieBrowser(
+								context,
+								Uri.https(widget.site.owoVgUrl, '/eck_bans'),
+								useFullWidthGestures: false
+							),
+							child: const Text('My Bans')
+						),
+						if (_meta?.metathreadUrl case final url?) AdaptiveThinButton(
+							onPressed: () => openCookieBrowser(context, Uri.parse(url), useFullWidthGestures: false),
+							child: const Text('Metathread')
+						),
+					]
+				),
+				const SizedBox(height: 8),
+				SwitchListTile(
+					title: Text(skipAutosolverLabel),
+					subtitle: Text(gold ? 'Force interactive captcha instead of autosolver' : 'Solve captcha yourself instead of waiting for autosolver'),
+					value: settings.owoVgManualCaptcha,
+					onChanged: (v) {
+						settings.owoVgManualCaptcha = v;
+						setState(() {});
+					}
+				),
+				if (gold) SwitchListTile(
+					title: const Text('Email IPs'),
+					value: settings.owoVgEmailIps,
+					onChanged: (v) {
+						settings.owoVgEmailIps = v;
+						setState(() {});
+					}
+				),
+				if (gold && _recycleIpOptions.isNotEmpty) ListTile(
+					title: const Text('Recycle IP'),
+					subtitle: DropdownButton<String>(
+						isExpanded: true,
+						value: settings.owoVgRecycleIps,
+						items: [
+							for (final (value, label) in _recycleIpOptions)
+								DropdownMenuItem(value: value, child: Text(label))
+						],
+						onChanged: (v) {
+							if (v == null) return;
+							settings.owoVgRecycleIps = v;
+							setState(() {});
+						}
+					)
+				),
+				if (gold && (_meta?.emailVerificationProviders.isNotEmpty ?? false)) ListTile(
+					title: const Text('Email type'),
+					subtitle: DropdownButton<String>(
+						isExpanded: true,
+						value: settings.owoVgEmailVerificationStock.isEmpty ? '' : settings.owoVgEmailVerificationStock,
+						items: [
+							const DropdownMenuItem(value: '', child: Text('Auto (server pool)')),
+							for (final provider in _meta!.emailVerificationProviders.where((p) => p.id.isNotEmpty && !p.disabled))
+								DropdownMenuItem(
+									value: provider.id,
+									child: Text(_providerLabel(provider))
+								)
+						],
+						onChanged: (v) {
+							settings.owoVgEmailVerificationStock = v ?? '';
+							setState(() {});
+						}
+					)
+				),
+				SwitchListTile(
+					title: const Text('Change hash'),
+					subtitle: const Text('Recompress uploaded file to change perceptual hash'),
+					value: settings.owoVgRecompression,
+					onChanged: (v) {
+						settings.owoVgRecompression = v;
+						setState(() {});
+					}
+				),
+				ExpansionTile(
+					title: const Text('Gimmicks'),
+					children: [
+						SwitchListTile(
+							title: const Text('Evade perceptual hash'),
+							value: settings.owoVgAntiphash,
+							onChanged: (v) {
+								settings.owoVgAntiphash = v;
+								setState(() {});
+							}
+						),
+						ListTile(
+							title: const Text('Fake thumbnail'),
+							subtitle: Text(widget.extras.fakeThumbnail?.afterLast('/') ?? 'None selected'),
+							trailing: Row(
+								mainAxisSize: MainAxisSize.min,
+								children: [
+									if (widget.extras.fakeThumbnail != null) IconButton(
+										icon: const Icon(CupertinoIcons.xmark),
+										onPressed: () => _update(widget.extras.copyWith(clearFakeThumbnail: true))
+									),
+									IconButton(
+										icon: const Icon(CupertinoIcons.photo),
+										onPressed: _pickFakeThumbnail
+									)
+								]
+							)
+						)
+					]
+				),
+				ListTile(
+					title: const Text('PEE'),
+					subtitle: Text(widget.extras.peeFiles.isEmpty ? 'No hidden embed files' : describeCount(widget.extras.peeFiles.length, 'file')),
+					trailing: Row(
+						mainAxisSize: MainAxisSize.min,
+						children: [
+							if (widget.extras.peeFiles.isNotEmpty) IconButton(
+								icon: const Icon(CupertinoIcons.trash),
+								onPressed: () => _update(const OwoVgPostExtras())
+							),
+							IconButton(
+								icon: const Icon(CupertinoIcons.add),
+								onPressed: _pickPeeFiles
+							)
+						]
+					)
+				),
+				Padding(
+					padding: const EdgeInsets.symmetric(horizontal: 16),
+					child: TextField(
+						controller: _peeTextController,
+						maxLines: 2,
+						decoration: const InputDecoration(
+							labelText: 'PEE text',
+							hintText: 'Hidden text that PEE users see in your file'
+						),
+						onChanged: (v) => _update(widget.extras.copyWith(peeText: v)),
+					)
+				),
+				const SizedBox(height: 8)
+				],
+			]
+		);
+	}
+
+	String _providerLabel(OwoVgEmailVerificationProvider provider) {
+		final parts = [provider.label];
+		if (provider.stockDisplay != null) parts.add('stock ${provider.stockDisplay}');
+		if (provider.successRateDisplay != null) parts.add(provider.successRateDisplay!);
+		return parts.join(' | ');
+	}
+}

--- a/lib/widgets/reply_box.dart
+++ b/lib/widgets/reply_box.dart
@@ -19,7 +19,11 @@ import 'package:chan/services/imageboard.dart';
 import 'package:chan/services/linkifier.dart';
 import 'package:chan/services/md5.dart';
 import 'package:chan/services/media.dart';
+import 'package:chan/models/owovg_post_extras.dart';
 import 'package:chan/services/outbox.dart';
+import 'package:chan/services/owovg.dart';
+import 'package:chan/sites/4chan.dart';
+import 'package:chan/widgets/owovg_reply_extras.dart';
 import 'package:chan/services/persistence.dart';
 import 'package:chan/services/pick_attachment.dart';
 import 'package:chan/services/settings.dart';
@@ -131,6 +135,9 @@ class ReplyBoxState extends State<ReplyBox> {
 	PickedAttachment? _originalAttachment;
 	String? get attachmentExt => attachment?.file.path.afterLast('.').toLowerCase();
 	bool _showOptions = false;
+	bool _showOwoVgExtras = false;
+	bool get showOwoVgExtras => _showOwoVgExtras && !loading;
+	OwoVgPostExtras _owoVgExtras = OwoVgPostExtras.empty;
 	bool get showOptions => _showOptions && !loading;
 	bool _showAttachmentOptions = false;
 	bool get showAttachmentOptions => _showAttachmentOptions && !loading && attachment != null;
@@ -394,15 +401,8 @@ class ReplyBoxState extends State<ReplyBox> {
 		_textFieldController.addListener(_onTextChanged);
 		_subjectFieldController.addListener(_didUpdateDraft);
 		_filenameController.addListener(_onFilenameChanged);
-		context.read<ImageboardSite>().getBoardFlags(widget.board.s).then((flags) {
-			if (!mounted) return;
-			setState(() {
-				_flags = flags;
-			});
-		}).catchError((Object e, StackTrace st) {
-			Future.error(e, st); // Crashlytics
-			print('Error getting flags for ${widget.board}: $e');
-		});
+		Settings.instance.addListener(_onPostingBackendChanged);
+		_loadBoardFlags();
 		if (_nameFieldController.text.isNotEmpty || _optionsFieldController.text.isNotEmpty || (_disableLoginSystem && hasLoginSystem)) {
 			_showOptions = true;
 		}
@@ -417,12 +417,26 @@ class ReplyBoxState extends State<ReplyBox> {
 			draft = widget.initialDraft;
 		}
 		if (oldWidget.board != widget.board) {
-			context.read<ImageboardSite>().getBoardFlags(widget.board.s).then((flags) {
-				setState(() {
-					_flags = flags;
-				});
-			});
+			_loadBoardFlags();
 		}
+	}
+
+	void _loadBoardFlags() {
+		context.read<ImageboardSite>().getBoardFlags(widget.board.s).then((flags) {
+			if (!mounted) return;
+			setState(() {
+				_flags = flags;
+			});
+		}).catchError((Object e, StackTrace st) {
+			Future.error(e, st);
+			print('Error getting flags for ${widget.board}: $e');
+		});
+	}
+
+	void _onPostingBackendChanged() {
+		if (!mounted) return;
+		_loadBoardFlags();
+		setState(() {});
 	}
 
 	void _tryUsingInitialFile(DraftPost? draft) async {
@@ -1046,12 +1060,19 @@ Future<bool> _handleImagePaste({bool manual = true}) async {
 		return justOnce ?? Settings.autoLoginOnMobileNetworkSetting.value ?? false;
 	}
 
+	void _setPendingOwoVgExtrasIfNeeded(Imageboard imageboard) {
+		if (imageboard.site is Site4Chan && Settings.instance.fourChanPostingBackend == OwoVgPostingBackend.owoVg) {
+			OwoVgService.pendingExtras = _owoVgExtras;
+		}
+	}
+
 	Future<void> _submit() async {
 		final shouldUseLoginSystem = await _shouldUseLoginSystem();
 		if (!mounted) {
 			return;
 		}
 		final imageboard = context.read<Imageboard>();
+		_setPendingOwoVgExtrasIfNeeded(imageboard);
 		lightHapticFeedback();
 		final post = _makeDraft();
 		post.name = _nameFieldController.text;
@@ -1078,6 +1099,7 @@ Future<bool> _handleImagePaste({bool manual = true}) async {
 						),
 						AdaptiveDialogAction(
 							onPressed: () {
+								_setPendingOwoVgExtrasIfNeeded(imageboard);
 								imageboard.persistence.browserState.outbox.add(post);
 								runWhenIdle(const Duration(milliseconds: 500), imageboard.persistence.didUpdateBrowserState);
 								final entry = Outbox.instance.submitPost(imageboard.key, post, QueueStateIdle());
@@ -2481,6 +2503,19 @@ Future<bool> _handleImagePaste({bool manual = true}) async {
 		);
 	}
 
+	Widget _buildOwoVgExtras(BuildContext context) {
+		final site = context.read<ImageboardSite>();
+		if (site is! Site4Chan) {
+			return const SizedBox.shrink();
+		}
+		return OwoVgReplyExtrasPanel(
+			site: site,
+			board: widget.board.s,
+			extras: _owoVgExtras,
+			onChanged: (extras) => setState(() => _owoVgExtras = extras)
+		);
+	}
+
 	Widget _buildButtons(BuildContext context) {
 		void expandAttachmentOptions() {
 			setState(() {
@@ -2493,11 +2528,18 @@ Future<bool> _handleImagePaste({bool manual = true}) async {
 				_showOptions = !_showOptions;
 			});
 		}
+		void expandOwoVgExtras() {
+			setState(() {
+				_showOwoVgExtras = !_showOwoVgExtras;
+			});
+		}
 		final imageboard = context.read<Imageboard>();
 		final emotes = imageboard.site.getEmotes();
 		final snippets = context.read<ImageboardSite>().getBoardSnippets(widget.board.s);
 		final defaultTextStyle = DefaultTextStyle.of(context).style;
 		final settings = context.watch<Settings>();
+		final isSite4Chan = imageboard.site is Site4Chan;
+		final useOwoVgPosting = isSite4Chan && settings.fourChanPostingBackend == OwoVgPostingBackend.owoVg;
 		return Row(
 			mainAxisAlignment: MainAxisAlignment.end,
 			children: [
@@ -2628,7 +2670,7 @@ Future<bool> _handleImagePaste({bool manual = true}) async {
 									icon: const Icon(CupertinoIcons.smiley)
 								)
 							),
-							if (snippets.isNotEmpty || _flags.isNotEmpty || emotes.isNotEmpty) Container(
+							if (snippets.isNotEmpty || _flags.isNotEmpty || emotes.isNotEmpty || isSite4Chan) Container(
 								margin: const EdgeInsets.symmetric(horizontal: 8),
 								width: 1,
 								height: 32,
@@ -2762,6 +2804,16 @@ Future<bool> _handleImagePaste({bool manual = true}) async {
 						].reversed.toList()
 					)
 				),
+				if (isSite4Chan) AdaptiveIconButton(
+					onPressed: loading ? null : expandOwoVgExtras,
+					icon: Text(
+						'🐾',
+						style: TextStyle(
+							fontSize: 20,
+							color: useOwoVgPosting ? ChanceTheme.primaryColorOf(context) : null
+						)
+					)
+				),
 				AdaptiveIconButton(
 					onPressed: loading ? null : expandOptions,
 					icon: const Icon(CupertinoIcons.gear)
@@ -2783,6 +2835,7 @@ Future<bool> _handleImagePaste({bool manual = true}) async {
 						final persistence = context.read<Persistence>();
 						final post = _makeDraft();
 						post.name = _nameFieldController.text;
+						_setPendingOwoVgExtrasIfNeeded(imageboard);
 						persistence.browserState.outbox.add(post);
 						runWhenIdle(const Duration(milliseconds: 500), persistence.didUpdateBrowserState);
 						final entry = Outbox.instance.submitPost(imageboard.key, post, QueueStateIdle());
@@ -2856,6 +2909,7 @@ Future<bool> _handleImagePaste({bool manual = true}) async {
 		}
 		// Add the old content as a draft to the outbox, if non-trivial
 		if (_isNonTrivial(old) && old != entry.post) {
+			_setPendingOwoVgExtrasIfNeeded(context.read<Imageboard>());
 			Outbox.instance.submitPost(context.read<Imageboard>().key, old, QueueStateIdle());
 		}
 		setState(() {});
@@ -2865,6 +2919,7 @@ Future<bool> _handleImagePaste({bool manual = true}) async {
 	Widget build(BuildContext context) {
 		_chanTabs = context.watchIdentity<ChanTabs?>();
 		final settings = context.watch<Settings>();
+		final isSite4Chan = context.read<ImageboardSite>() is Site4Chan;
 		return Focus(
 			focusNode: _rootFocusNode,
 			child: TransformedMediaQuery(
@@ -2888,6 +2943,12 @@ Future<bool> _handleImagePaste({bool manual = true}) async {
 								bottomSafe: true,
 								curve: Curves.ease,
 								child: _buildAttachmentOptions(context)
+							),
+							Expander(
+								expanded: show && showOwoVgExtras && isSite4Chan,
+								bottomSafe: true,
+								curve: Curves.ease,
+								child: _buildOwoVgExtras(context)
 							),
 							Expander(
 								expanded: show && showOptions,
@@ -2944,6 +3005,16 @@ Future<bool> _handleImagePaste({bool manual = true}) async {
 										child: Focus(
 											descendantsAreFocusable: showAttachmentOptions && show,
 											child: _buildAttachmentOptions(context)
+										)
+									)
+								),
+								SliverToBoxAdapter(
+									child: Expander(
+										expanded: showOwoVgExtras && show && isSite4Chan,
+										bottomSafe: true,
+										child: Focus(
+											descendantsAreFocusable: showOwoVgExtras && show,
+											child: _buildOwoVgExtras(context)
 										)
 									)
 								),
@@ -3074,6 +3145,7 @@ Future<bool> _handleImagePaste({bool manual = true}) async {
 				widget.onDraftChanged(null);
 			}
 		}
+		Settings.instance.removeListener(_onPostingBackendChanged);
 		_textFieldController.dispose();
 		_nameFieldController.dispose();
 		_subjectFieldController.dispose();

--- a/lib/widgets/util.dart
+++ b/lib/widgets/util.dart
@@ -25,6 +25,7 @@ import 'package:chan/widgets/adaptive.dart';
 import 'package:chan/widgets/attachment_thumbnail.dart';
 import 'package:chan/widgets/css_colors.dart';
 import 'package:chan/widgets/cupertino_inkwell.dart';
+import 'package:chan/widgets/html_rich_text.dart';
 import 'package:chan/widgets/imageboard_scope.dart';
 import 'package:chan/widgets/timed_rebuilder.dart';
 import 'package:dio/dio.dart';
@@ -44,7 +45,7 @@ Future<void> alert(BuildContext context, String title, String message, {
 	Map<String, FutureOr<void> Function()> actions = const {},
 	bool barrierDismissible = true
 }) async {
-	final looksForeign = title.looksForeign || message.looksForeign;
+	final looksForeign = !containsHtml(message) && (title.looksForeign || message.looksForeign);
 	bool translating = false;
 	String? translatedTitle;
 	String? translatedMessage;
@@ -55,7 +56,13 @@ Future<void> alert(BuildContext context, String title, String message, {
 		builder: (context) => StatefulBuilder(
 			builder: (context, setState) => AdaptiveAlertDialog(
 				title: Text(translatedTitle ?? title),
-				content: Text(translatedMessage ?? message),
+				content: () {
+					final body = translatedMessage ?? message;
+					if (containsHtml(body)) {
+						return HtmlRichText(html: body);
+					}
+					return Text(body);
+				}(),
 				actions: [
 					for (final action in actions.entries) AdaptiveDialogAction(
 						onPressed: () async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -166,10 +166,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   charset_converter:
     dependency: "direct main"
     description:
@@ -186,6 +186,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
+  cli_config:
+    dependency: transitive
+    description:
+      name: cli_config
+      sha256: ac20a183a07002b700f0c25e61b7ee46b23c309d76ab7b7640a028f18e4d99ec
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   cli_util:
     dependency: transitive
     description:
@@ -255,10 +263,10 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: "576aaab8b1abdd452e0f656c3e73da9ead9d7880e15bdc494189d9c1a1baf0db"
+      sha256: "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.15.0"
   cross_file:
     dependency: transitive
     description:
@@ -1056,18 +1064,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   media_kit:
     dependency: "direct main"
     description:
@@ -1126,10 +1134,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: "direct main"
     description:
@@ -1652,26 +1660,26 @@ packages:
     dependency: "direct main"
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.17"
   timezone:
     dependency: transitive
     description:
@@ -1881,7 +1889,7 @@ packages:
     source: hosted
     version: "0.1.6"
   web_socket_channel:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: web_socket_channel
       sha256: "9f187088ed104edd8662ca07af4b124465893caf063ba29758f97af57e61da8f"
@@ -1937,5 +1945,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.35.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -99,6 +99,7 @@ dependencies:
   path_provider: ^2.0.10
   path_provider_ios: ^2.0.11
   async: ^2.9.0
+  web_socket_channel: ^3.0.1
   flutter_email_sender: ^6.0.3
   dynamic_color: ^1.5.2
   flutter:


### PR DESCRIPTION
## Summary

- Adds an optional **owo.vg posting backend** for 4chan, selectable per-post from the reply box (paw button panel) or configured in site settings.
- Adds **Gold Pass login** for owo.vg accounts, with saved credentials and auto-login before posting.
- Integrates **reply-box extras** for owo.vg-specific options (pool selection, captcha mode, gold-only toggles, announcements, feedback, etc.).
- Reuses the existing **native 4chan task captcha UI** when owo.vg requires a captcha during posting, including solver hint borders (green = selected, orange = suggested).
- Improves **HTML error dialogs** so rate-limit and help links render correctly instead of showing raw markup.
- Adds **email verification hCaptcha support** via WebSocket `email_hcaptcha` prompts with an inline hCaptcha dialog.
- Fixes **email verification task captchas** to submit `solve_email` instead of `solve`, so all four verify stages can complete.
- Shows **longer status toasts** during email verify (e.g. waiting for / visiting verification link).
- Fixes **looping WebSocket status notifications**: status toasts are replaced instead of queued, repeated tags refresh in place, and WebSocket events are handled serially.
- Improves **WebSocket reliability** during long posts: client pings every 20s for server keepalive and a wakelock is held for the duration of posting.

## Details

- New service layer handles owo.vg posting, metadata, cookies, and session state.
- 4chan site integration routes `submitPost` / captcha handling through the selected backend.
- Settings are persisted via new Hive fields (`settings.g.dart` updated).
- Adds `web_socket_channel` dependency for posting transport.

## Not included

- No signing keys, keystores, or local build config changes.
- No version/build number bumps.

## Test plan

- [x] Post to 4chan with default (direct) backend — unchanged behavior
- [x] Switch to owo.vg backend in reply box and post a reply
- [x] Log in with Gold Pass and verify gold-only options appear
- [x] Trigger a captcha and confirm native task UI + hint/selection borders
- [x] Trigger a rate-limit error and confirm line breaks + tappable help link
- [x] Post with Email IPs enabled and complete both hCaptcha stages + both task captchas
- [x] Confirm status toasts appear during email verify (waiting for link, visiting link, context verified)
- [x] Confirm repeated status tags refresh without looping back to older messages
- [x] Confirm WebSocket stays connected during long email verify waits (no random disconnect)
- [x] Verify CI/release build still succeeds without local gradle overrides